### PR TITLE
Add .mjs as file extension for JavaScript

### DIFF
--- a/assets/database_languages.json
+++ b/assets/database_languages.json
@@ -113,7 +113,8 @@
   {
     "language": "Javascript",
     "extensions": [
-      "js"
+      "js",
+      "mjs"
     ]
   },
   {


### PR DESCRIPTION
`.mjs` is becoming the standard extension for Node.js ES2015 module system.