### PR TITLE
validate languages.json during constants generation

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -39,8 +39,14 @@ var LanguageFeatures = map[string]LanguageFeature{}
 func processConstants() {
 	var database map[string]Language
 	startTime := makeTimestampMilli()
-	data, _ := base64.StdEncoding.DecodeString(languages)
-	json.Unmarshal(data, &database)
+	data, err := base64.StdEncoding.DecodeString(languages)
+	if err != nil {
+		panic(fmt.Sprintf("failed to base64 decode languages: %v", err))
+	}
+
+	if err := json.Unmarshal(data, &database); err != nil {
+		panic(fmt.Sprintf("languages json invalid: %v", err))
+	}
 
 	if Trace {
 		printTrace(fmt.Sprintf("milliseconds unmarshal: %d", makeTimestampMilli()-startTime))

--- a/scripts/include.go
+++ b/scripts/include.go
@@ -4,44 +4,76 @@ package main
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"strings"
 )
 
-func readFile(filepath string) []byte {
-	bytes, err := ioutil.ReadFile(filepath)
+const constantsFile = "./processor/constants.go"
 
-	if err != nil {
-		fmt.Print(err)
-	}
-
-	return bytes
+func fatalf(f string, v ...interface{}) {
+	fmt.Fprintf(os.Stderr, f+"\n", v...)
+	os.Exit(1)
 }
 
 // Reads all .json files in the current folder
 // and encodes them as strings literals in constants.go
-func main() {
+func generateConstants() error {
 	files, _ := ioutil.ReadDir(".")
-	out, _ := os.Create("./processor/constants.go")
+	out, err := ioutil.TempFile(".", "temp_constants")
+	if err != nil {
+		return fmt.Errorf("failed to open temp file: %v", err)
+	}
+	defer os.Remove(out.Name())
 
 	// Open constants
 	out.Write([]byte("package processor \n\nconst (\n"))
 
 	for _, f := range files {
 		if strings.HasPrefix(f.Name(), "languages") && strings.HasSuffix(f.Name(), ".json") {
+			f, err := os.Open(f.Name())
+			if err != nil {
+				return fmt.Errorf("failed to open file '%s': %v", f.Name(), err)
+			}
+
+			// validate the json by decoding into an empty struct
+			if err := json.NewDecoder(f).Decode(&struct{}{}); err != nil {
+				return fmt.Errorf("failed to validate json in file '%s': %v", f.Name(), err)
+			}
+
+			// Reset position
+			f.Seek(0, io.SeekStart)
+
 			// The constant variable name
 			out.Write([]byte(strings.TrimSuffix(f.Name(), ".json") + " = `"))
 
-			contents, _ := ioutil.ReadFile(f.Name())
-			str := base64.StdEncoding.EncodeToString(contents)
+			enc := base64.NewEncoder(base64.StdEncoding, out)
+			if _, err := io.Copy(enc, f); err != nil {
+				return fmt.Errorf("failed to encode file '%s': %v", f.Name(), err)
+			}
+			enc.Close()
 
-			out.Write([]byte(str))
 			out.Write([]byte("`\n"))
 		}
 	}
 
 	// Close out constants
 	out.Write([]byte(")\n"))
+	out.Close()
+
+	if err := os.Rename(out.Name(), constantsFile); err != nil {
+		return fmt.Errorf("%v", err)
+	}
+
+	return nil
+}
+
+func main() {
+	if err := generateConstants(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to generate constants: %v\n", err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
I was trying to add a new language definition to languages.json but, as
is with json, the pesky commas and other syntax was getting in the way.
When running `go generate` invalid JSON is encoded into constants.go and
then scc would just silently igore the error.  As a result no language
definitions would load.

This add some basic JSON validation to the go generate process as well
as exposes some other possible errors.  It also will generate the
constants to a temporary file before copying over making the process
more atomic and not clobbering a file on a failure.

Since there is now json validation a panic as added to scc itself to
barf if it can't read the json data.