### PR TITLE
bitmask prefilter for code scanning

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -64,21 +64,30 @@ func ProcessConstants() {
 	for name, value := range database {
 		complexityBytes := []byte{}
 		complexityChecks := [][]byte{}
+		complexityMask := byte(0)
 		singleLineComment := [][]byte{}
+		singleLineCommentMask := byte(0)
 		multiLineComment := []OpenClose{}
+		multiLineCommentMask := byte(0)
 		stringChecks := []OpenClose{}
+		stringMask := byte(0)
 		processBytes := []byte{}
+		processMask := byte(0)
 
 		for _, v := range value.ComplexityChecks {
 			complexityBytes = append(complexityBytes, v[0])
 			complexityChecks = append(complexityChecks, []byte(v))
 			processBytes = append(processBytes, v[0])
+			complexityMask |= v[0]
 		}
+		processMask |= complexityMask
 
 		for _, v := range value.LineComment {
 			singleLineComment = append(singleLineComment, []byte(v))
 			processBytes = append(processBytes, v[0])
+			singleLineCommentMask |= v[0]
 		}
+		processMask |= singleLineCommentMask
 
 		for _, v := range value.MultiLine {
 			multiLineComment = append(multiLineComment, OpenClose{
@@ -86,7 +95,9 @@ func ProcessConstants() {
 				Close: []byte(v[1]),
 			})
 			processBytes = append(processBytes, v[0][0])
+			multiLineCommentMask |= v[0][0]
 		}
+		processMask |= multiLineCommentMask
 
 		for _, v := range value.Quotes {
 			stringChecks = append(stringChecks, OpenClose{
@@ -94,16 +105,23 @@ func ProcessConstants() {
 				Close: []byte(v[1]),
 			})
 			processBytes = append(processBytes, v[0][0])
+			stringMask |= v[0][0]
 		}
+		processMask |= stringMask
 
 		LanguageFeatures[name] = LanguageFeature{
 			ComplexityBytes:   uniqueByte(complexityBytes),
 			ComplexityChecks:  complexityChecks,
+			ComplexityCheckMask: complexityMask,
 			MultiLineComment:  multiLineComment,
+			MultiLineCommentMask: multiLineCommentMask,
 			SingleLineComment: singleLineComment,
+			SingleLineCommentMask: singleLineCommentMask,
 			StringChecks:      stringChecks,
+			StringCheckMask: stringMask,
 			Nested:            value.NestedMultiLine,
 			ProcessBytes:	   uniqueByte(processBytes),
+			ProcessMask:       processMask,
 		}
 	}
 

--- a/processor/structs.go
+++ b/processor/structs.go
@@ -17,12 +17,17 @@ type Language struct {
 
 type LanguageFeature struct {
 	ComplexityChecks  [][]byte
+	ComplexityCheckMask byte
 	ComplexityBytes   []byte
 	SingleLineComment [][]byte
+	SingleLineCommentMask byte
 	MultiLineComment  []OpenClose
+	MultiLineCommentMask byte
 	StringChecks      []OpenClose
+	StringCheckMask byte
 	Nested            bool
 	ProcessBytes      []byte
+	ProcessMask       byte
 }
 
 // FileJobCallback is an interface that FileJobs can implement to get a per line callback with the line type

--- a/processor/workers_test.go
+++ b/processor/workers_test.go
@@ -557,8 +557,9 @@ func TestCheckForMatchNoMatch(t *testing.T) {
 		[]byte("//"),
 		[]byte("--"),
 	}
+	mask := byte('/') | byte('-')
 
-	match := checkForMatch(' ', 0, 100, matches, &fileJob)
+	match := checkForMatch(' ', 0, 100, mask, matches, &fileJob)
 
 	if match != false {
 		t.Errorf("Expected no match")
@@ -577,8 +578,9 @@ func TestCheckForMatchHasMatch(t *testing.T) {
 		[]byte("//"),
 		[]byte("--"),
 	}
+	mask := byte('/') | byte('-')
 
-	match := checkForMatch('/', 0, 100, matches, &fileJob)
+	match := checkForMatch('/', 0, 100, mask, matches, &fileJob)
 
 	if match != true {
 		t.Errorf("Expected match")
@@ -594,8 +596,9 @@ func TestCheckForMatchSingleNoMatch(t *testing.T) {
 	}
 
 	matches := []byte("*/")
+	mask := byte('*')
 
-	match := checkForMatchSingle('/', 0, 100, matches, &fileJob)
+	match := checkForMatchSingle('/', 0, 100, mask, matches, &fileJob)
 
 	if match != false {
 		t.Errorf("Expected no match")
@@ -611,8 +614,9 @@ func TestCheckForMatchSingleMatch(t *testing.T) {
 	}
 
 	matches := []byte("*/")
+	mask := byte('*')
 
-	match := checkForMatchSingle('*', 0, 100, matches, &fileJob)
+	match := checkForMatchSingle('*', 0, 100, mask, matches, &fileJob)
 
 	if match != true {
 		t.Errorf("Expected match")
@@ -633,8 +637,9 @@ func TestCheckComplexityMatch(t *testing.T) {
 	}
 
 	complexityBytes := []byte("f")
+	mask := byte('f')
 
-	match := checkComplexity('f', 0, 20, matches, complexityBytes, &fileJob)
+	match := checkComplexity('f', 0, 20, mask, matches, complexityBytes, &fileJob)
 
 	if match != 4 {
 		t.Errorf("Expected match")
@@ -655,8 +660,9 @@ func TestCheckComplexityNoMatch(t *testing.T) {
 	}
 
 	complexityBytes := []byte("f")
+	mask := byte('f')
 
-	match := checkComplexity('f', 0, 20, matches, complexityBytes, &fileJob)
+	match := checkComplexity('f', 0, 20, mask, matches, complexityBytes, &fileJob)
 
 	if match != 0 {
 		t.Errorf("Expected no match")
@@ -1126,11 +1132,15 @@ func BenchmarkCheckComplexity(b *testing.B) {
 	}
 
 	complexityBytes := []byte("fiswe|&!=")
+	mask := byte(0)
+	for _, b := range complexityBytes {
+		mask |= b
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < len(fileJob.Content); j++ {
-			checkComplexity(fileJob.Content[j], j, len(fileJob.Content), matches, complexityBytes, &fileJob)
+			checkComplexity(fileJob.Content[j], j, len(fileJob.Content), mask, matches, complexityBytes, &fileJob)
 		}
 	}
 }


### PR DESCRIPTION
Use a bitmask pre-filter before entering string/comment checks, in a
way conceptually similar to bloom filters.

I've redone this PR from scratch, since master had diverged enough to make a git rebase problematic. However, the performance seems worse overall than the original PR, so I'm going to leave that up for now.