### PR TITLE
fix regression in some multiline comment parsing

### DIFF
--- a/processor/workers.go
+++ b/processor/workers.go
@@ -280,7 +280,7 @@ func commentState(fileJob *FileJob, index int, endPoint int, slCommentMask byte,
 			return index, endComments, offsetJump, currentState, endString
 		}
 
-		if checkForMatchSingle(fileJob.Content[index], index, endPoint, slCommentMask, endComments[len(endComments)-1], fileJob) {
+		if checkForMatchSingle(fileJob.Content[index], index, endPoint, byte(0xFF), endComments[len(endComments)-1], fileJob) {
 			// set offset jump here
 			offsetJump = len(endComments[len(endComments)-1])
 			endComments = endComments[:len(endComments)-1]

--- a/processor/workers_test.go
+++ b/processor/workers_test.go
@@ -686,15 +686,15 @@ t`)
 	}
 
 	if fileJob.Code != 1 {
-		t.Errorf("Expected 1 lines got %d", fileJob.Code)
+		t.Errorf("Expected 1 code lines got %d", fileJob.Code)
 	}
 
 	if fileJob.Comment != 2 {
-		t.Errorf("Expected 2 lines got %d", fileJob.Comment)
+		t.Errorf("Expected 2 comment lines got %d", fileJob.Comment)
 	}
 
 	if fileJob.Blank != 0 {
-		t.Errorf("Expected 0 lines got %d", fileJob.Blank)
+		t.Errorf("Expected 0 blank lines got %d", fileJob.Blank)
 	}
 }
 


### PR DESCRIPTION
We don't have a mask for endComment matching, and the single line
comment mask got dropped in when I was find/replacing stuff. Using 0xFF
as a mask will match anything, which is a quick fix.