### PR TITLE
bound goroutine counts

### DIFF
--- a/processor/file.go
+++ b/processor/file.go
@@ -47,7 +47,7 @@ func getExtension(name string) string {
 // in the supplied directory. Tests using a single process showed no lack of performance
 // even when hitting older spinning platter disks for this way
 //func walkDirectoryParallel(root string, output *RingBuffer) {
-func walkDirectoryParallel(root string, output *chan *FileJob) {
+func walkDirectoryParallel(root string, output chan *FileJob) {
 	startTime := makeTimestampMilli()
 	blackList := strings.Split(PathBlacklist, ",")
 	whiteList := strings.Split(WhiteListExtensions, ",")
@@ -97,7 +97,7 @@ func walkDirectoryParallel(root string, output *chan *FileJob) {
 				go func(toWalk string) {
 					filejobs := walkDirectory(toWalk, blackList, extensionLookup)
 					for i := 0; i < len(filejobs); i++ {
-						*output <- &filejobs[i]
+						output <- &filejobs[i]
 					}
 
 					mutex.Lock()
@@ -130,7 +130,7 @@ func walkDirectoryParallel(root string, output *chan *FileJob) {
 				}
 
 				if ok {
-					*output <- &FileJob{Location: filepath.Join(root, f.Name()), Filename: f.Name(), Extension: extension, Language: language}
+					output <- &FileJob{Location: filepath.Join(root, f.Name()), Filename: f.Name(), Extension: extension, Language: language}
 					mutex.Lock()
 					totalCount++
 					mutex.Unlock()
@@ -142,7 +142,7 @@ func walkDirectoryParallel(root string, output *chan *FileJob) {
 	}
 
 	wg.Wait()
-	close(*output)
+	close(output)
 	if Debug {
 		printDebug(fmt.Sprintf("milliseconds to walk directory: %d", makeTimestampMilli()-startTime))
 	}

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -64,11 +64,11 @@ func sortSummaryFiles(summary *LanguageSummary) {
 	}
 }
 
-func toJson(input *chan *FileJob) string {
+func toJson(input chan *FileJob) string {
 	languages := map[string]LanguageSummary{}
 	var sumFiles, sumLines, sumCode, sumComment, sumBlank, sumComplexity int64 = 0, 0, 0, 0, 0, 0
 
-	for res := range *input {
+	for res := range input {
 		sumFiles++
 		sumLines += res.Lines
 		sumCode += res.Code
@@ -124,7 +124,7 @@ func toJson(input *chan *FileJob) string {
 	return string(jsonString)
 }
 
-func toCSV(input *chan *FileJob) string {
+func toCSV(input chan *FileJob) string {
 	records := [][]string{{
 		"Language",
 		"Location",
@@ -136,7 +136,7 @@ func toCSV(input *chan *FileJob) string {
 		"Complexity"},
 	}
 
-	for result := range *input {
+	for result := range input {
 		records = append(records, []string{
 			result.Language,
 			result.Location,
@@ -156,20 +156,20 @@ func toCSV(input *chan *FileJob) string {
 	return b.String()
 }
 
-func fileSummerize(input *chan *FileJob) string {
+func fileSummarize(input chan *FileJob) string {
 	switch {
 	case More || strings.ToLower(Format) == "wide":
-		return fileSummerizeLong(input)
+		return fileSummarizeLong(input)
 	case strings.ToLower(Format) == "json":
 		return toJson(input)
 	case strings.ToLower(Format) == "csv":
 		return toCSV(input)
 	}
 
-	return fileSummerizeShort(input)
+	return fileSummarizeShort(input)
 }
 
-func fileSummerizeLong(input *chan *FileJob) string {
+func fileSummarizeLong(input chan *FileJob) string {
 	var str strings.Builder
 
 	str.WriteString(tabularWideBreak)
@@ -183,7 +183,7 @@ func fileSummerizeLong(input *chan *FileJob) string {
 	var sumFiles, sumLines, sumCode, sumComment, sumBlank, sumComplexity int64 = 0, 0, 0, 0, 0, 0
 	var sumWeightedComplexity float64 = 0
 
-	for res := range *input {
+	for res := range input {
 		sumFiles++
 		sumLines += res.Lines
 		sumCode += res.Code
@@ -326,7 +326,7 @@ func fileSummerizeLong(input *chan *FileJob) string {
 	return str.String()
 }
 
-func fileSummerizeShort(input *chan *FileJob) string {
+func fileSummarizeShort(input chan *FileJob) string {
 	var str strings.Builder
 
 	str.WriteString(tabularShortBreak)
@@ -343,7 +343,7 @@ func fileSummerizeShort(input *chan *FileJob) string {
 	languages := map[string]LanguageSummary{}
 	var sumFiles, sumLines, sumCode, sumComment, sumBlank, sumComplexity int64 = 0, 0, 0, 0, 0, 0
 
-	for res := range *input {
+	for res := range input {
 		sumFiles++
 		sumLines += res.Lines
 		sumCode += res.Code

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -23,6 +23,6 @@ func BenchmarkFileSummerize(b *testing.B) {
 		close(fileSummaryJobQueue)
 		b.StartTimer()
 
-		fileSummerize(&fileSummaryJobQueue)
+		fileSummarize(fileSummaryJobQueue)
 	}
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -28,8 +28,10 @@ var FileOutput = ""
 var PathBlacklist = ""
 var FileListQueueSize = runtime.NumCPU()
 var FileReadJobQueueSize = runtime.NumCPU()
+var FileReadJobWorkers = runtime.NumCPU() * 4
 var FileReadContentJobQueueSize = runtime.NumCPU()
 var FileProcessJobQueueSize = runtime.NumCPU()
+var FileProcessJobWorkers = runtime.NumCPU() * 4
 var FileSummaryJobQueueSize = runtime.NumCPU()
 var WhiteListExtensions = ""
 var AverageWage int64 = 56286
@@ -214,11 +216,11 @@ func Process() {
 	fileReadContentJobQueue := make(chan *FileJob, FileReadContentJobQueueSize) // Files ready to be processed
 	fileSummaryJobQueue := make(chan *FileJob, FileSummaryJobQueueSize)         // Files ready to be summerised
 
-	go walkDirectoryParallel(DirFilePaths[0], &fileListQueue)
-	go fileReaderWorker(&fileListQueue, &fileReadContentJobQueue)
-	go fileProcessorWorker(&fileReadContentJobQueue, &fileSummaryJobQueue)
+	go walkDirectoryParallel(DirFilePaths[0], fileListQueue)
+	go fileReaderWorker(fileListQueue, fileReadContentJobQueue)
+	go fileProcessorWorker(fileReadContentJobQueue, fileSummaryJobQueue)
 
-	result := fileSummerize(&fileSummaryJobQueue)
+	result := fileSummarize(fileSummaryJobQueue)
 
 	if FileOutput == "" {
 		fmt.Println(result)


### PR DESCRIPTION
scc was starting to be capable of launching goroutines at a rate which
can lead to launching too many OS threads:

    * linux-4.19-rc1 on a 16 core c5.4xlarge:
    runtime: failed to create new OS thread (have 4090 already; errno=11)
    runtime: may need to increase max user processes (ulimit -u)
    fatal error: newosproc

this change bounds the number of goroutine workers to avoid this, while
still creating enough to saturate the CPU. This includes a marginal
improvement in performance, and appears to make the runtime much more
consistent:

    * linux-4.19-rc1 on a 4 core c5.xlarge:
    before: Time (mean ± σ):      4.680 s ±  0.727 s    [User: 17.920 s, System: 0.632 s]
    after:  Time (mean ± σ):      4.532 s ±  0.005 s    [User: 17.340 s, System: 0.705 s]