### PR TITLE
implement tries for token matching

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -69,57 +69,33 @@ func ProcessConstants() {
 
 	startTime = makeTimestampMilli()
 	for name, value := range database {
-		complexityChecks := [][]byte{}
-		complexityMask := byte(0)
-		singleLineComment := [][]byte{}
-		singleLineCommentMask := byte(0)
-		multiLineComment := []OpenClose{}
-		multiLineCommentMask := byte(0)
-		stringChecks := []OpenClose{}
-		stringMask := byte(0)
-		processMask := byte(0)
+		complexityTrie := &Trie{}
+		slCommentTrie := &Trie{}
+		mlCommentTrie := &Trie{}
+		stringTrie := &Trie{}
 
 		for _, v := range value.ComplexityChecks {
-			complexityChecks = append(complexityChecks, []byte(v))
-			complexityMask |= v[0]
+			complexityTrie.Insert([]byte(v))
 		}
-		processMask |= complexityMask
 
 		for _, v := range value.LineComment {
-			singleLineComment = append(singleLineComment, []byte(v))
-			singleLineCommentMask |= v[0]
+			slCommentTrie.Insert([]byte(v))
 		}
-		processMask |= singleLineCommentMask
 
 		for _, v := range value.MultiLine {
-			multiLineComment = append(multiLineComment, OpenClose{
-				Open:  []byte(v[0]),
-				Close: []byte(v[1]),
-			})
-			multiLineCommentMask |= v[0][0]
+			mlCommentTrie.InsertClose([]byte(v[0]), []byte(v[1]))
 		}
-		processMask |= multiLineCommentMask
 
 		for _, v := range value.Quotes {
-			stringChecks = append(stringChecks, OpenClose{
-				Open:  []byte(v[0]),
-				Close: []byte(v[1]),
-			})
-			stringMask |= v[0][0]
+			stringTrie.InsertClose([]byte(v[0]), []byte(v[1]))
 		}
-		processMask |= stringMask
 
 		LanguageFeatures[name] = LanguageFeature{
-			ComplexityChecks:      complexityChecks,
-			ComplexityCheckMask:   complexityMask,
-			MultiLineComment:      multiLineComment,
-			MultiLineCommentMask:  multiLineCommentMask,
-			SingleLineComment:     singleLineComment,
-			SingleLineCommentMask: singleLineCommentMask,
-			StringChecks:          stringChecks,
-			StringCheckMask:       stringMask,
+			Complexity: complexityTrie,
+			MultiLineComments: mlCommentTrie,
+			SingleLineComments: slCommentTrie,
+			Strings: stringTrie,
 			Nested:                value.NestedMultiLine,
-			ProcessMask:           processMask,
 		}
 	}
 


### PR DESCRIPTION
Replaces matching of [][]byte slices with a trie / prefix tree.
Invalidates the need for pre-checking with bitmasks or otherwise.

Improves performance by ~15% in my testing:

 4 cores, master: Time (mean ± σ):      6.360 s ±  0.007 s    [User: 24.677 s, System: 0.679 s]
 4 cores, tries:  Time (mean ± σ):      5.489 s ±  0.008 s    [User: 21.145 s, System: 0.690 s]

 8 cores, master: Time (mean ± σ):      3.217 s ±  0.005 s    [User: 24.840 s, System: 0.708 s]
 8 cores, tries:  Time (mean ± σ):      2.784 s ±  0.005 s    [User: 21.270 s, System: 0.733 s]

16 cores, master: Time (mean ± σ):      1.660 s ±  0.016 s    [User: 24.936 s, System: 0.778 s]
16 cores, tries:  Time (mean ± σ):      1.446 s ±  0.014 s    [User: 21.378 s, System: 0.801 s]