### PR TITLE
merged trie for codeState/blankState

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -73,6 +73,7 @@ func ProcessConstants() {
 		slCommentTrie := &Trie{}
 		mlCommentTrie := &Trie{}
 		stringTrie := &Trie{}
+		tokenTrie := &Trie{}
 
 		complexityMask := byte(0)
 		singleLineCommentMask := byte(0)
@@ -82,25 +83,33 @@ func ProcessConstants() {
 
 		for _, v := range value.ComplexityChecks {
 			complexityMask |= v[0]
-			complexityTrie.Insert([]byte(v))
+			complexityTrie.Insert(T_COMPLEXITY, []byte(v))
+			if !Complexity {
+				tokenTrie.Insert(T_COMPLEXITY, []byte(v))
+			}
 		}
-		processMask |= complexityMask
+		if !Complexity {
+			processMask |= complexityMask
+		}
 
 		for _, v := range value.LineComment {
 			singleLineCommentMask |= v[0]
-			slCommentTrie.Insert([]byte(v))
+			slCommentTrie.Insert(T_SLCOMMENT, []byte(v))
+			tokenTrie.Insert(T_SLCOMMENT, []byte(v))
 		}
 		processMask |= singleLineCommentMask
 
 		for _, v := range value.MultiLine {
 			multiLineCommentMask |= v[0][0]
-			mlCommentTrie.InsertClose([]byte(v[0]), []byte(v[1]))
+			mlCommentTrie.InsertClose(T_MLCOMMENT, []byte(v[0]), []byte(v[1]))
+			tokenTrie.InsertClose(T_MLCOMMENT, []byte(v[0]), []byte(v[1]))
 		}
 		processMask |= multiLineCommentMask
 
 		for _, v := range value.Quotes {
 			stringMask |= v[0][0]
-			stringTrie.InsertClose([]byte(v[0]), []byte(v[1]))
+			stringTrie.InsertClose(T_STRING, []byte(v[0]), []byte(v[1]))
+			tokenTrie.InsertClose(T_STRING, []byte(v[0]), []byte(v[1]))
 		}
 		processMask |= stringMask
 
@@ -109,6 +118,7 @@ func ProcessConstants() {
 			MultiLineComments:     mlCommentTrie,
 			SingleLineComments:    slCommentTrie,
 			Strings:               stringTrie,
+			Tokens:                tokenTrie,
 			Nested:                value.NestedMultiLine,
 			ComplexityCheckMask:   complexityMask,
 			MultiLineCommentMask:  multiLineCommentMask,

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -93,7 +93,7 @@ func stringState(fileJob *FileJob, index int, endPoint int, stringTrie *Trie, en
 		}
 
 		if fileJob.Content[i-1] != '\\' {
-			if ok, _, _ := stringTrie.Match(fileJob.Content[i:]); ok {
+			if ok, _, _ := stringTrie.Match(fileJob.Content[i:]); ok != 0 {
 				return i, S_CODE
 			}
 		}
@@ -125,40 +125,34 @@ func codeState(
 			return i, currentState, endString, endComments
 		}
 
-		if shouldProcess(curByte, langFeatures.ProcessMask) {
-			if ok, _, endString := langFeatures.Strings.Match(fileJob.Content[i:]); ok {
-				currentState = S_STRING
-				return i, currentState, endString, endComments
-			}
+		if Duplicates {
+			// Technically this is wrong because we skip bytes so this is not a true
+			// hash of the file contents, but for duplicate files it shouldn't matter
+			// as both will skip the same way
+			digestible := []byte{fileJob.Content[index]}
+			(*digest).Write(digestible)
+		}
 
-			if Duplicates {
-				// Technically this is wrong because we skip bytes so this is not a true
-				// hash of the file contents, but for duplicate files it shouldn't matter
-				// as both will skip the same way
-				digestible := []byte{fileJob.Content[index]}
-				(*digest).Write(digestible)
-			}
+		switch tokenType, offsetJump, endString := langFeatures.Tokens.Match(fileJob.Content[i:]); tokenType {
+		case T_STRING:
+			currentState = S_STRING
+			return i, currentState, endString, endComments
 
-			if ok, _, _ := langFeatures.SingleLineComments.Match(fileJob.Content[i:]); ok {
-				currentState = S_COMMENT_CODE
-				return i, currentState, endString, endComments
-			}
+		case T_SLCOMMENT:
+			currentState = S_COMMENT_CODE
+			return i, currentState, endString, endComments
 
+		case T_MLCOMMENT:
 			if langFeatures.Nested || len(endComments) == 0 {
-				if ok, offsetJump, endString := langFeatures.MultiLineComments.Match(fileJob.Content[i:]); ok {
-					endComments = append(endComments, endString)
-					currentState = S_MULTICOMMENT_CODE
-					i += offsetJump - 1
-					return i, currentState, endString, endComments
-				}
+				endComments = append(endComments, endString)
+				currentState = S_MULTICOMMENT_CODE
+				i += offsetJump - 1
+				return i, currentState, endString, endComments
 			}
 
-			if !Complexity {
-				if index == 0 || isWhitespace(fileJob.Content[index-1]) {
-					if ok, _, _ := langFeatures.Complexity.Match(fileJob.Content[i:]); ok {
-						fileJob.Complexity++
-					}
-				}
+		case T_COMPLEXITY:
+			if index == 0 || isWhitespace(fileJob.Content[index-1]) {
+				fileJob.Complexity++
 			}
 		}
 	}
@@ -197,7 +191,7 @@ func commentState(fileJob *FileJob, index int, endPoint int, currentState int64,
 		// Check if we are entering another multiline comment
 		// This should come below check for match single as it speeds up processing
 		if langFeatures.Nested || len(endComments) == 0 {
-			if ok, offsetJump, endString := langFeatures.MultiLineComments.Match(fileJob.Content[i:]); ok {
+			if ok, offsetJump, endString := langFeatures.MultiLineComments.Match(fileJob.Content[i:]); ok != 0 {
 				endComments = append(endComments, endString)
 				i += offsetJump - 1
 				return i, currentState, endString, endComments
@@ -217,34 +211,31 @@ func blankState(
 	endString []byte,
 	langFeatures LanguageFeature,
 ) (int, int64, []byte, [][]byte) {
-	if langFeatures.Nested || len(endComments) == 0 {
-		if ok, offsetJump, endString := langFeatures.MultiLineComments.Match(fileJob.Content[index:]); ok {
+	switch tokenType, offsetJump, endString := langFeatures.Tokens.Match(fileJob.Content[index:]); tokenType {
+	case T_MLCOMMENT:
+		if langFeatures.Nested || len(endComments) == 0 {
 			endComments = append(endComments, endString)
 			currentState = S_MULTICOMMENT
 			index += offsetJump - 1
 			return index, currentState, endString, endComments
 		}
-	}
 
-	// Moving this above nested comments slows performance to leave it below
-	if ok, _, _ := langFeatures.SingleLineComments.Match(fileJob.Content[index:]); ok {
+	case T_SLCOMMENT:
 		currentState = S_COMMENT
 		return index, currentState, endString, endComments
-	}
 
-	// Moving this above nested comments or single line comment checks slows performance so leave it below
-	if ok, _, _ := langFeatures.Strings.Match(fileJob.Content[index:]); ok {
+	case T_STRING:
 		currentState = S_STRING
 		return index, currentState, endString, endComments
-	}
 
-	currentState = S_CODE
-	if !Complexity {
+	case T_COMPLEXITY:
+		currentState = S_CODE
 		if index == 0 || isWhitespace(fileJob.Content[index-1]) {
-			if ok, _, _ := langFeatures.Complexity.Match(fileJob.Content[index:]); ok {
-				fileJob.Complexity++
-			}
+			fileJob.Complexity++
 		}
+
+	default:
+		currentState = S_CODE
 	}
 
 	return index, currentState, endString, endComments
@@ -277,6 +268,9 @@ func CountStats(fileJob *FileJob) {
 	}
 	if langFeatures.Strings == nil {
 		langFeatures.Strings = &Trie{}
+	}
+	if langFeatures.Tokens == nil {
+		langFeatures.Tokens = &Trie{}
 	}
 
 	endPoint := int(fileJob.Bytes - 1)

--- a/processor/workers_test.go
+++ b/processor/workers_test.go
@@ -554,12 +554,12 @@ func TestCheckForMatchNoMatch(t *testing.T) {
 	}
 
 	matches := &Trie{}
-	matches.Insert([]byte("//"))
-	matches.Insert([]byte("--"))
+	matches.Insert(T_SLCOMMENT, []byte("//"))
+	matches.Insert(T_SLCOMMENT, []byte("--"))
 
 	match, _, _ := matches.Match(fileJob.Content)
 
-	if match != false {
+	if match != 0 {
 		t.Errorf("Expected no match")
 	}
 }
@@ -573,12 +573,12 @@ func TestCheckForMatchHasMatch(t *testing.T) {
 	}
 
 	matches := &Trie{}
-	matches.Insert([]byte("//"))
-	matches.Insert([]byte("--"))
+	matches.Insert(T_SLCOMMENT, []byte("//"))
+	matches.Insert(T_SLCOMMENT, []byte("--"))
 
 	match, _, _ := matches.Match(fileJob.Content)
 
-	if match != true {
+	if match != T_SLCOMMENT {
 		t.Errorf("Expected match")
 	}
 }
@@ -626,12 +626,12 @@ func TestCheckComplexityMatch(t *testing.T) {
 	}
 
 	matches := &Trie{}
-	matches.Insert([]byte("for "))
-	matches.Insert([]byte("for("))
+	matches.Insert(T_COMPLEXITY, []byte("for "))
+	matches.Insert(T_COMPLEXITY, []byte("for("))
 
 	match, n, _ := matches.Match(fileJob.Content)
 
-	if !match || n != 4 {
+	if match != T_COMPLEXITY || n != 4 {
 		t.Errorf("Expected match")
 	}
 }
@@ -645,12 +645,12 @@ func TestCheckComplexityNoMatch(t *testing.T) {
 	}
 
 	matches := &Trie{}
-	matches.Insert([]byte("for "))
-	matches.Insert([]byte("for("))
+	matches.Insert(T_COMPLEXITY, []byte("for "))
+	matches.Insert(T_COMPLEXITY, []byte("for("))
 
 	match, _, _ := matches.Match(fileJob.Content)
 
-	if match {
+	if match != 0 {
 		t.Errorf("Expected no match")
 	}
 }
@@ -1133,17 +1133,17 @@ func BenchmarkCheckComplexity(b *testing.B) {
 	}
 
 	matches := &Trie{}
-	matches.Insert([]byte("for "))
-	matches.Insert([]byte("for("))
-	matches.Insert([]byte("if "))
-	matches.Insert([]byte("if("))
-	matches.Insert([]byte("switch "))
-	matches.Insert([]byte("while "))
-	matches.Insert([]byte("else "))
-	matches.Insert([]byte("|| "))
-	matches.Insert([]byte("&& "))
-	matches.Insert([]byte("!= "))
-	matches.Insert([]byte("== "))
+	matches.Insert(T_COMPLEXITY, []byte("for "))
+	matches.Insert(T_COMPLEXITY, []byte("for("))
+	matches.Insert(T_COMPLEXITY, []byte("if "))
+	matches.Insert(T_COMPLEXITY, []byte("if("))
+	matches.Insert(T_COMPLEXITY, []byte("switch "))
+	matches.Insert(T_COMPLEXITY, []byte("while "))
+	matches.Insert(T_COMPLEXITY, []byte("else "))
+	matches.Insert(T_COMPLEXITY, []byte("|| "))
+	matches.Insert(T_COMPLEXITY, []byte("&& "))
+	matches.Insert(T_COMPLEXITY, []byte("!= "))
+	matches.Insert(T_COMPLEXITY, []byte("== "))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Changes tries to include the token type (string, comment, etc) in the leaves. This allows all the tokens to be packed into a single trie for codeState/blankState.

    # scc linux-4.19-rc1
    before: Time (mean ± σ):      1.437 s ±  0.013 s    [User: 21.352 s, System: 0.767 s]
    after:  Time (mean ± σ):     826.1 ms ±  17.7 ms    [User: 11.270 s, System: 0.748 s]
    
    # scc -c linux-4.19-rc1
    Time (mean ± σ):      1.299 s ±  0.016 s    [User: 19.019 s, System: 0.764 s]
    Time (mean ± σ):     575.7 ms ±  17.5 ms    [User: 7.140 s, System: 0.736 s]