### PR TITLE
Improve exclusion matching

### DIFF
--- a/processor/file.go
+++ b/processor/file.go
@@ -181,15 +181,15 @@ func walkDirectory(toWalk string, blackList []string, extensionLookup map[string
 	extension := ""
 	var filejobs []FileJob
 
+	var regex *regexp.Regexp
+	if Exclude != "" {
+		regex = regexp.MustCompile(Exclude)
+	}
+
 	godirwalk.Walk(toWalk, &godirwalk.Options{
 		// Unsorted is meant to make the walk faster and we need to sort after processing anyway
 		Unsorted: true,
 		Callback: func(root string, info *godirwalk.Dirent) error {
-
-			var regex *regexp.Regexp
-			if Exclude != "" {
-				regex = regexp.MustCompile(Exclude)
-			}
 
 			if Exclude != "" {
 				if regex.Match([]byte(info.Name())) {

--- a/processor/file.go
+++ b/processor/file.go
@@ -200,6 +200,9 @@ func walkDirectory(toWalk string, blackList []string, extensionLookup map[string
 							printWarn("skipping file due to match exclude: " + root)
 						}
 					}
+					if info.IsDir() {
+						return filepath.SkipDir
+					}
 					return nil
 				}
 			}


### PR DESCRIPTION
This started as me trying to figure out why `scc --exclude-dir .git,vendor ~/go/src` wasn't actually excluding vendored code. It turns out the directory exclusions are only applied at the top level and also have to include the root if `.` isn't used.

When looking at the code I noticed that the exclusion regexp matching is _not_ done against full paths but is only compared to the directory entry's name so I attempted to use `scc --not-match '^vendor|\.git$ ~/go/src` which still didn't quite work. Adding `--verbose` showed that it was _claiming_ to be skipping the `.git` and `vendor` directories, so the pattern was working, but the logs also showed notices about files _inside_ those directories (eg. `HEAD`, `pack-*`, various unknown file extensions inside vendored paths).

The first patch speeds things up, especially since excluded directories don't actually get pruned. The speed up is pretty noticeable if you've got a lot of repos with large `vendor` directories that you're trying to exclude.

The second patch fixes the pruning behaviour. Since it can result in significantly smaller traversals it can also dramatically speed things up.

**These contributions are licensed under the MIT license and Unlicense.**