### PR TITLE
Lazy loading

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 		Run: func(cmd *cobra.Command, args []string) {
 			processor.DirFilePaths = args
 			processor.ConfigureGc()
+			processor.ConfigureLazy(true)
 			processor.Process()
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 		Use:     "scc",
 		Short:   "scc DIRECTORY",
 		Long:    "Sloc, Cloc and Code. Count lines of code in a directory with complexity estimation.\nBen Boyter <ben@boyter.org> + Contributors",
-		Version: "2.0.0",
+		Version: "2.1.0",
 		Run: func(cmd *cobra.Command, args []string) {
 			processor.DirFilePaths = args
 			processor.ConfigureGc()

--- a/processor/file.go
+++ b/processor/file.go
@@ -114,9 +114,10 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 					filejobs := walkDirectory(toWalk, PathBlacklist, extensionLookup)
 					for i := 0; i < len(filejobs); i++ {
 						mutex.Lock()
-						LoadLanguageFeature(filejobs[i].Language)
 						totalCount += len(filejobs)
 						mutex.Unlock()
+
+						LoadLanguageFeature(filejobs[i].Language)
 						output <- &filejobs[i]
 					}
 
@@ -159,11 +160,10 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 
 					if ok {
 						mutex.Lock()
-						// If we have the extension then load in the features for it
-						LoadLanguageFeature(language)
 						totalCount++
 						mutex.Unlock()
 
+						LoadLanguageFeature(language)
 						output <- &FileJob{Location: filepath.Join(root, f.Name()), Filename: f.Name(), Extension: extension, Language: language}
 					} else if Verbose {
 						printWarn(fmt.Sprintf("skipping file unknown extension: %s", f.Name()))

--- a/processor/file.go
+++ b/processor/file.go
@@ -113,13 +113,13 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 				go func(toWalk string) {
 					filejobs := walkDirectory(toWalk, PathBlacklist, extensionLookup)
 					for i := 0; i < len(filejobs); i++ {
-						mutex.Lock()
-						totalCount += len(filejobs)
-						mutex.Unlock()
-
 						LoadLanguageFeature(filejobs[i].Language)
 						output <- &filejobs[i]
 					}
+
+					mutex.Lock()
+					totalCount += len(filejobs)
+					mutex.Unlock()
 
 					// Turn GC back to what it was before if we have parsed enough files
 					if !resetGc && totalCount >= GcFileCount {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -87,6 +87,8 @@ func ProcessConstants() {
 		if Trace {
 			printTrace(fmt.Sprintf("milliseconds build language features: %d", makeTimestampMilli()-startTime))
 		}
+	} else {
+		printTrace("configured to lazy load language features")
 	}
 }
 
@@ -112,7 +114,11 @@ func LoadLanguageFeature(loadName string) {
 		}
 	}
 
+	startTime := makeTimestampNano()
 	processLanguageFeature(loadName, value)
+	if Trace {
+		printTrace(fmt.Sprintf("nanoseconds to build language %s features: %d", loadName, makeTimestampNano()-startTime))
+	}
 }
 
 func processLanguageFeature(name string, value Language) {

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -257,7 +257,9 @@ func CountStats(fileJob *FileJob) {
 		return
 	}
 
+	LanguageFeaturesMutex.Lock()
 	langFeatures := LanguageFeatures[fileJob.Language]
+	LanguageFeaturesMutex.Unlock()
 
 	if langFeatures.Complexity == nil {
 		langFeatures.Complexity = &Trie{}

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -337,6 +337,8 @@ func CountStats(fileJob *FileJob) {
 			}
 		}
 
+		// Only check the first 10000 characters for null bytes indicating a binary file
+		// and if we find it then we return otherwise carry on and ignore binary markers
 		if index < 10000 && fileJob.Binary {
 			return
 		}


### PR DESCRIPTION
Modify scc to only load language features as required rather then doing all 222 in a single pass. 
Since the loading of features is a fairly heavy task the savings for the majority of cases is worth it. 
This is especially noticeable when working on smaller repositories.

Version 2.1.0 (with the update) vs 2.0.0 with the full load.

```
$ hyperfine './scc redis-5.0.2' && hyperfine 'scc redis-5.0.2'
Benchmark #1: ./scc redis-5.0.2

  Time (mean ± σ):      81.6 ms ±   5.0 ms    [User: 173.8 ms, System: 265.4 ms]

  Range (min … max):    75.5 ms …  97.1 ms

Benchmark #1: scc redis-5.0.2

  Time (mean ± σ):     124.4 ms ±   2.4 ms    [User: 168.6 ms, System: 289.1 ms]

  Range (min … max):   120.0 ms … 128.4 ms
```

NB this should be backwards compatible with library users as it is only enabled via the main.go file.
