### PR TITLE
Accept a single file as a command line argument #54

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 
 	rootCmd := &cobra.Command{
 		Use:     "scc",
-		Short:   "scc DIRECTORY",
+		Short:   "scc [FILE or DIRECTORY]",
 		Long:    "Sloc, Cloc and Code. Count lines of code in a directory with complexity estimation.\nBen Boyter <ben@boyter.org> + Contributors",
 		Version: "2.1.0",
 		Run: func(cmd *cobra.Command, args []string) {

--- a/processor/file.go
+++ b/processor/file.go
@@ -76,6 +76,8 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 
 	var isSoloFile bool = false
 	var all []os.FileInfo
+	// clean path including trailing slashes
+	root = filepath.Clean(root)
 	target, _ := os.Lstat(root)
 	if !target.IsDir() {
 		// create an array with a single FileInfo

--- a/processor/file.go
+++ b/processor/file.go
@@ -5,6 +5,7 @@ import (
 	"github.com/karrick/godirwalk"
 	"github.com/monochromegane/go-gitignore"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
@@ -72,7 +73,18 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 	totalCount := 0
 
 	var wg sync.WaitGroup
-	all, _ := ioutil.ReadDir(root)
+
+	var is_solo_file bool = false
+	var all []os.FileInfo
+	target, _ := os.Lstat(root)
+	if !target.IsDir() {
+		// create an array with a single FileInfo
+		all = append(all, target)
+		is_solo_file = true
+	} else {
+		all, _ = ioutil.ReadDir(root)
+	}
+
 	// TODO the gitignore should check for further gitignores deeper in the tree
 	gitignore, gitignoreerror := gitignore.NewGitIgnore(filepath.Join(root, ".gitignore"))
 	resetGc := false
@@ -83,6 +95,7 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 		regex = regexp.MustCompile(Exclude)
 	}
 
+	var fpath string
 	for _, f := range all {
 		// Godirwalk despite being faster than the default walk is still too slow to feed the
 		// CPU's and so we need to walk in parallel to keep up as much as possible
@@ -130,7 +143,12 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 				}(filepath.Join(root, f.Name()))
 			}
 		} else { // File processing starts here
-			if gitignoreerror != nil || !gitignore.Match(filepath.Join(root, f.Name()), false) {
+			if is_solo_file {
+				fpath = root
+			} else {
+				fpath = filepath.Join(root, f.Name())
+			}
+			if gitignoreerror != nil || !gitignore.Match(fpath, false) {
 
 				shouldSkip := false
 				if Exclude != "" {
@@ -164,7 +182,7 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 						mutex.Unlock()
 
 						LoadLanguageFeature(language)
-						output <- &FileJob{Location: filepath.Join(root, f.Name()), Filename: f.Name(), Extension: extension, Language: language}
+						output <- &FileJob{Location: fpath, Filename: f.Name(), Extension: extension, Language: language}
 					} else if Verbose {
 						printWarn(fmt.Sprintf("skipping file unknown extension: %s", f.Name()))
 					}

--- a/processor/file.go
+++ b/processor/file.go
@@ -74,13 +74,13 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 
 	var wg sync.WaitGroup
 
-	var is_solo_file bool = false
+	var isSoloFile bool = false
 	var all []os.FileInfo
 	target, _ := os.Lstat(root)
 	if !target.IsDir() {
 		// create an array with a single FileInfo
 		all = append(all, target)
-		is_solo_file = true
+		isSoloFile = true
 	} else {
 		all, _ = ioutil.ReadDir(root)
 	}
@@ -143,7 +143,7 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 				}(filepath.Join(root, f.Name()))
 			}
 		} else { // File processing starts here
-			if is_solo_file {
+			if isSoloFile {
 				fpath = root
 			} else {
 				fpath = filepath.Join(root, f.Name())

--- a/processor/file_test.go
+++ b/processor/file_test.go
@@ -119,6 +119,31 @@ func TestWalkDirectoryParallelWorksWithSingleInputFile(t *testing.T) {
 	}
 }
 
+func TestWalkDirectoryParallelIgnoresRootTrailingSlash(t *testing.T) {
+	isLazy = false
+	ProcessConstants()
+
+	WhiteListExtensions = []string{"go"}
+	Exclude = "vendor"
+	PathBlacklist = []string{"vendor"}
+	Verbose = true
+	Trace = true
+	Debug = true
+	GcFileCount = 10
+
+	inputChan := make(chan *FileJob, 10000)
+	walkDirectoryParallel("file_test.go/", inputChan)
+
+	count := 0
+	for range inputChan {
+		count++
+	}
+
+	if count != 1 {
+		t.Error("Expected exactly one file")
+	}
+}
+
 func TestWalkDirectory(t *testing.T) {
 	Debug = true
 	Exclude = "test"

--- a/processor/file_test.go
+++ b/processor/file_test.go
@@ -94,6 +94,31 @@ func TestWalkDirectoryParallel(t *testing.T) {
 	}
 }
 
+func TestWalkDirectoryParallelWorksWithSingleInputFile(t *testing.T) {
+	isLazy = false
+	ProcessConstants()
+
+	WhiteListExtensions = []string{"go"}
+	Exclude = "vendor"
+	PathBlacklist = []string{"vendor"}
+	Verbose = true
+	Trace = true
+	Debug = true
+	GcFileCount = 10
+
+	inputChan := make(chan *FileJob, 10000)
+	walkDirectoryParallel("file_test.go", inputChan)
+
+	count := 0
+	for range inputChan {
+		count++
+	}
+
+	if count != 1 {
+		t.Error("Expected exactly one file")
+	}
+}
+
 func TestWalkDirectory(t *testing.T) {
 	Debug = true
 	Exclude = "test"

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"runtime"
 	"runtime/debug"
 	"sort"
@@ -307,6 +308,11 @@ func Process() {
 	// Clean up any invalid arguments before setting everything up
 	if len(DirFilePaths) == 0 {
 		DirFilePaths = append(DirFilePaths, ".")
+	}
+
+	if _, err := os.Stat(DirFilePaths[0]); os.IsNotExist(err) {
+		fmt.Println("file or directory does not exists: " + DirFilePaths[0])
+		return
 	}
 
 	SortBy = strings.ToLower(SortBy)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"runtime"
 	"runtime/debug"
 	"sort"
@@ -309,9 +310,10 @@ func Process() {
 	if len(DirFilePaths) == 0 {
 		DirFilePaths = append(DirFilePaths, ".")
 	}
+	fpath := filepath.Clean(DirFilePaths[0])
 
-	if _, err := os.Stat(DirFilePaths[0]); os.IsNotExist(err) {
-		fmt.Println("file or directory does not exists: " + DirFilePaths[0])
+	if _, err := os.Stat(fpath); os.IsNotExist(err) {
+		fmt.Println("file or directory does not exists: " + fpath)
 		return
 	}
 
@@ -327,7 +329,7 @@ func Process() {
 	fileReadContentJobQueue := make(chan *FileJob, FileReadContentJobQueueSize) // Files ready to be processed
 	fileSummaryJobQueue := make(chan *FileJob, FileSummaryJobQueueSize)         // Files ready to be summarised
 
-	go walkDirectoryParallel(DirFilePaths[0], fileListQueue)
+	go walkDirectoryParallel(fpath, fileListQueue)
 	go fileReaderWorker(fileListQueue, fileReadContentJobQueue)
 	go fileProcessorWorker(fileReadContentJobQueue, fileSummaryJobQueue)
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -85,7 +85,7 @@ var GcFileCount = 10000
 var gcPercent = -1
 var isLazy = false
 
-// DirFilePaths is not set via flags but by arguments following the the flags for directories to process
+// DirFilePaths is not set via flags but by arguments following the flags for file or directory to process
 var DirFilePaths = []string{}
 
 // Raw languageDatabase loaded

--- a/test-all.sh
+++ b/test-all.sh
@@ -73,6 +73,14 @@ do
     fi
 done
 
+if ./scc main.go > /dev/null ; then
+    echo -e "${GREEN}PASSED file specified test"
+else
+    echo -e "${RED}======================================================="
+    echo -e "FAILED Should run correctly with a file is specified"
+    echo -e "================================================="
+    exit
+fi
 
 echo -e "${NC}Cleaning up..."
 rm ./scc


### PR DESCRIPTION
This patch allow to run the scc CLI with a single file path as an argument
rather than a directory.
I explicitly license my contribution under a choice MIT or The Unlicense.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>