### PR TITLE
.gitignore improvements

### DIFF
--- a/processor/file.go
+++ b/processor/file.go
@@ -91,6 +91,13 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 
 	// TODO the gitIgnore should check for further gitignores deeper in the tree
 	gitIgnore, gitIgnoreError := gitignore.NewGitIgnore(filepath.Join(root, ".gitignore"))
+	if Verbose {
+		if gitIgnoreError == nil {
+			printWarn(fmt.Sprintf("found and loaded gitignore file: %s", filepath.Join(root, ".gitignore")))
+		} else {
+			printWarn(fmt.Sprintf("no gitignore found: %s", filepath.Join(root, ".gitignore")))
+		}
+	}
 
 	resetGc := false
 
@@ -126,7 +133,7 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 				}
 			}
 
-			if gitIgnoreError != nil || gitIgnore.Match(filepath.Join(root, f.Name()), true) {
+			if gitIgnoreError == nil && gitIgnore.Match(filepath.Join(root, f.Name()), true) {
 				if Verbose {
 					printWarn("skipping directory due to git ignore: " + filepath.Join(root, f.Name()))
 				}
@@ -163,7 +170,7 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 
 			shouldSkip := false
 
-			if gitIgnoreError != nil || gitIgnore.Match(fpath, false) {
+			if gitIgnoreError == nil && gitIgnore.Match(fpath, false) {
 				if Verbose {
 					printWarn("skipping file due to git ignore: " + f.Name())
 				}

--- a/processor/file.go
+++ b/processor/file.go
@@ -76,7 +76,7 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 
 	var wg sync.WaitGroup
 
-	var isSoloFile = false
+	isSoloFile := false
 	var all []os.FileInfo
 	// clean path including trailing slashes
 	root = filepath.Clean(root)

--- a/processor/file.go
+++ b/processor/file.go
@@ -76,7 +76,7 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 
 	var wg sync.WaitGroup
 
-	var isSoloFile bool = false
+	var isSoloFile = false
 	var all []os.FileInfo
 	// clean path including trailing slashes
 	root = filepath.Clean(root)
@@ -89,8 +89,9 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 		all, _ = ioutil.ReadDir(root)
 	}
 
-	// TODO the gitignore should check for further gitignores deeper in the tree
-	gitignore, gitignoreerror := gitignore.NewGitIgnore(filepath.Join(root, ".gitignore"))
+	// TODO the gitIgnore should check for further gitignores deeper in the tree
+	gitIgnore, gitIgnoreError := gitignore.NewGitIgnore(filepath.Join(root, ".gitignore"))
+
 	resetGc := false
 
 	var regex *regexp.Regexp
@@ -125,6 +126,13 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 				}
 			}
 
+			if gitIgnoreError != nil || gitIgnore.Match(filepath.Join(root, f.Name()), true) {
+				if Verbose {
+					printWarn("skipping directory due to git ignore: " + filepath.Join(root, f.Name()))
+				}
+				shouldSkip = true
+			}
+
 			if !shouldSkip {
 				wg.Add(1)
 				go func(toWalk string) {
@@ -152,45 +160,51 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 			} else {
 				fpath = filepath.Join(root, f.Name())
 			}
-			if gitignoreerror != nil || !gitignore.Match(fpath, false) {
 
-				shouldSkip := false
-				if Exclude != "" {
-					if regex.Match([]byte(f.Name())) {
-						if Verbose {
-							printWarn("skipping file due to match exclude: " + f.Name())
-						}
-						shouldSkip = true
+			shouldSkip := false
+
+			if gitIgnoreError != nil || gitIgnore.Match(fpath, false) {
+				if Verbose {
+					printWarn("skipping file due to git ignore: " + f.Name())
+				}
+				shouldSkip = true
+			}
+
+			if Exclude != "" {
+				if regex.Match([]byte(f.Name())) {
+					if Verbose {
+						printWarn("skipping file due to match exclude: " + f.Name())
 					}
+					shouldSkip = true
+				}
+			}
+
+			if !shouldSkip {
+				extension := ""
+				// Lookup in case the full name matches
+				language, ok := extensionLookup[strings.ToLower(f.Name())]
+
+				// If no match check if we have a matching extension
+				if !ok {
+					extension = getExtension(f.Name())
+					language, ok = extensionLookup[extension]
 				}
 
-				if !shouldSkip {
-					extension := ""
-					// Lookup in case the full name matches
-					language, ok := extensionLookup[strings.ToLower(f.Name())]
+				// Convert from d.ts to ts and check that in case of multiple extensions
+				if !ok {
+					language, ok = extensionLookup[getExtension(extension)]
+				}
 
-					// If no match check if we have a matching extension
-					if !ok {
-						extension = getExtension(f.Name())
-						language, ok = extensionLookup[extension]
+				if ok {
+					atomic.AddInt64(&totalCount, 1)
+
+					for _, l := range language {
+						LoadLanguageFeature(l)
 					}
 
-					// Convert from d.ts to ts and check that in case of multiple extensions
-					if !ok {
-						language, ok = extensionLookup[getExtension(extension)]
-					}
-
-					if ok {
-						atomic.AddInt64(&totalCount, 1)
-
-						for _, l := range language {
-							LoadLanguageFeature(l)
-						}
-
-						output <- &FileJob{Location: fpath, Filename: f.Name(), Extension: extension, PossibleLanguages: language}
-					} else if Verbose {
-						printWarn(fmt.Sprintf("skipping file unknown extension: %s", f.Name()))
-					}
+					output <- &FileJob{Location: fpath, Filename: f.Name(), Extension: extension, PossibleLanguages: language}
+				} else if Verbose {
+					printWarn(fmt.Sprintf("skipping file unknown extension: %s", f.Name()))
 				}
 			}
 		}

--- a/processor/file_test.go
+++ b/processor/file_test.go
@@ -90,7 +90,7 @@ func TestWalkDirectoryParallel(t *testing.T) {
 	}
 
 	if count == 0 {
-		t.Error("Expected at least one file")
+		t.Errorf("Expected at least one file got %d", count)
 	}
 }
 
@@ -115,7 +115,7 @@ func TestWalkDirectoryParallelWorksWithSingleInputFile(t *testing.T) {
 	}
 
 	if count != 1 {
-		t.Error("Expected exactly one file")
+		t.Errorf("Expected exactly one file got %d", count)
 	}
 }
 
@@ -140,13 +140,14 @@ func TestWalkDirectoryParallelIgnoresRootTrailingSlash(t *testing.T) {
 	}
 
 	if count != 1 {
-		t.Error("Expected exactly one file")
+		t.Errorf("Expected exactly one file got %d", count)
 	}
 }
 
 func TestWalkDirectory(t *testing.T) {
 	Debug = true
 	Exclude = "test"
+	ProcessConstants()
 	files := walkDirectory(".", []string{}, ExtensionToLanguage)
 
 	if len(files) == 0 {


### PR DESCRIPTION
The current .gitignore logic was pretty crappy, to the point it was effectively useless. I noticed that `scc` was needlessly walking things that should have been ignored and then usually discarding the results due to the whitelist.

This PR makes it work at the root level with the idea of building on it so that we can implement recursive .gitignore checks throughout the tree, and perhaps include hg ignore files in the future too. In short it is not meant to be the be all end all solution but at least gets the basics right.

In some cases this will improve performance and in others it will be worse, but more importantly it will improve relevance.

```
$ hyperfine './scc' 'scc'
Benchmark #1: ./scc
  Time (mean ± σ):      33.2 ms ±   2.2 ms    [User: 32.6 ms, System: 102.4 ms]
  Range (min … max):    30.3 ms …  41.9 ms

Benchmark #2: scc
  Time (mean ± σ):      38.1 ms ±   3.4 ms    [User: 31.6 ms, System: 104.6 ms]
  Range (min … max):    34.3 ms …  53.8 ms

Summary
  './scc' ran
    1.15x faster than 'scc'

$ hyperfine 'scc' '~/scc'
Benchmark #1: scc
  Time (mean ± σ):     114.7 ms ±   1.9 ms    [User: 225.0 ms, System: 531.2 ms]
  Range (min … max):   111.5 ms … 119.7 ms

Benchmark #2: ~/scc
  Time (mean ± σ):      56.1 ms ±   2.3 ms    [User: 92.4 ms, System: 195.8 ms]
  Range (min … max):    53.2 ms …  67.7 ms

Summary
  '~/scc' ran
    2.04x faster than 'scc'
```

Importantly while making this all sorts of tests broke, which was rather reassuring to me. I fixed all the logic errors eventually and now `test-all.sh` runs as expected.

```
$ ./test-all.sh
Running go fmt...
Running unit tests...
?       github.com/boyter/scc   [no test files]
ok      github.com/boyter/scc/processor 1.812s
?       github.com/boyter/scc/scripts   [no test files]
Building application...
Running integration tests...
Error: unknown flag: --not-a-real-option
Usage:
  scc [flags]

Flags:
      --avg-wage int          average wage value used for basic COCOMO calculation (default 56286)
      --binary                disable binary file detection
      --by-file               display output for every file
      --cocomo                remove COCOMO calculation output
      --debug                 enable debug output
      --exclude-dir strings   directories to exclude (default [.git,.hg,.svn])
      --file-gc-count int     number of files to parse before turning the GC on (default 10000)
  -f, --format string         set output format [tabular, wide, json, csv] (default "tabular")
  -h, --help                  help for scc
  -i, --include-ext strings   limit to file extensions [comma separated list: e.g. go,java,js]
  -l, --languages             print supported languages and extensions
  -c, --no-complexity         skip calculation of code complexity
  -d, --no-duplicates         remove duplicate files from stats and output
  -M, --not-match string      ignore files and directories matching regular expression
  -o, --output string         output filename (default stdout)
  -s, --sort string           column to sort by [files, name, lines, blanks, code, comments, complexity] (default "files")
  -t, --trace                 enable trace output. Not recommended when processing multiple files
  -v, --verbose               verbose output
      --version               version for scc
  -w, --wide                  wider output with additional statistics (implies --complexity)

PASSED invalid option test
PASSED no directory specified test
PASSED directory specified test
PASSED multiple options test
PASSED regular expression ignore test
PASSED shared extension test 1
PASSED shared extension test 2
PASSED shared extension test 3
PASSED concurrency issue test
PASSED file specified test
PASSED duplicates test
Cleaning up...
=================================================
ALL TESTS PASSED
=================================================
```