### PR TITLE
Add support to run over multiple files or directories

### DIFF
--- a/processor/file.go
+++ b/processor/file.go
@@ -218,7 +218,7 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 	}
 
 	wg.Wait()
-	close(output)
+
 	if Debug {
 		printDebug(fmt.Sprintf("milliseconds to walk directory: %d", makeTimestampMilli()-startTime))
 	}

--- a/processor/file_test.go
+++ b/processor/file_test.go
@@ -83,6 +83,7 @@ func TestWalkDirectoryParallel(t *testing.T) {
 
 	inputChan := make(chan *FileJob, 10000)
 	walkDirectoryParallel("../", inputChan)
+	close(inputChan)
 
 	count := 0
 	for range inputChan {
@@ -108,6 +109,7 @@ func TestWalkDirectoryParallelWorksWithSingleInputFile(t *testing.T) {
 
 	inputChan := make(chan *FileJob, 10000)
 	walkDirectoryParallel("file_test.go", inputChan)
+	close(inputChan)
 
 	count := 0
 	for range inputChan {
@@ -133,6 +135,7 @@ func TestWalkDirectoryParallelIgnoresRootTrailingSlash(t *testing.T) {
 
 	inputChan := make(chan *FileJob, 10000)
 	walkDirectoryParallel("file_test.go/", inputChan)
+	close(inputChan)
 
 	count := 0
 	for range inputChan {

--- a/test-all.sh
+++ b/test-all.sh
@@ -28,6 +28,15 @@ else
     echo -e "${GREEN}PASSED invalid option test"
 fi
 
+if ./scc NOTAREALDIRECTORYORFILE > /dev/null ; then
+    echo -e "${RED}================================================="
+    echo -e "FAILED Invalid file/directory should produce error code "
+    echo -e "======================================================="
+    exit
+else
+    echo -e "${GREEN}PASSED invalid file/directory test"
+fi
+
 if ./scc > /dev/null ; then
     echo -e "${GREEN}PASSED no directory specified test"
 else
@@ -114,6 +123,35 @@ else
     exit
 fi
 
+# Multiple directory or file arguments
+if ./scc main.go README.md | grep -q "Go " ; then
+    echo -e "${GREEN}PASSED multiple file argument test 1"
+else
+    echo -e "${RED}======================================================="
+    echo -e "FAILED Should work with multiple file arguments 1"
+    echo -e "======================================================="
+    exit
+fi
+
+if ./scc main.go README.md | grep -q "Markdown " ; then
+    echo -e "${GREEN}PASSED multiple file argument test 2"
+else
+    echo -e "${RED}======================================================="
+    echo -e "FAILED Should work with multiple file arguments 2"
+    echo -e "======================================================="
+    exit
+fi
+
+if ./scc processor scripts > /dev/null ; then
+    echo -e "${GREEN}PASSED multiple directory specified test"
+else
+    echo -e "${RED}======================================================="
+    echo -e "FAILED Should run correctly with multiple directory specified"
+    echo -e "================================================="
+    exit
+fi
+
+
 # Try out duplicates
 for i in {1..100}
 do
@@ -128,14 +166,13 @@ do
 done
 echo -e "${GREEN}PASSED duplicates test"
 
-
 # Try out specific languages
 # TODO make this a loop with every example
 if ./scc "examples/language/" | grep -q "Bosque "; then
-    echo -e "${GREEN}PASSED Bosque Language Check"
+    echo -e "${GREEN}PASSED bosque Language Check"
 else
     echo -e "${RED}======================================================="
-    echo -e "FAILED Should be able to find Bosque"
+    echo -e "FAILED Should be able to find bosque"
     echo -e "======================================================="
     exit
 fi


### PR DESCRIPTION
Implements request https://github.com/boyter/scc/issues/61 where you can pass in multiple files or directories on the command line and scc will process them as instructed. Biggest change is that the file walker is no longer responsible for closing its stream. This makes the code that spawns them a little more ugly since it now needs to have a waitgroup to track this but I don't seen an obvious way to improve it.

Appears to work over everything I tried. There may be the old ulimit issue again if the directories passed in are large enough, but I was not able to trigger it on my machine.

