### PR TITLE
Make --exclude a StringArray argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,11 +104,11 @@ func main() {
 		false,
 		"remove duplicate files from stats and output",
 	)
-	flags.StringVarP(
+	flags.StringArrayVarP(
 		&processor.Exclude,
 		"not-match",
 		"M",
-		"",
+		[]string{},
 		"ignore files and directories matching regular expression",
 	)
 	flags.StringVarP(

--- a/processor/file.go
+++ b/processor/file.go
@@ -101,10 +101,10 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 
 	resetGc := false
 
-	var regex *regexp.Regexp
+	var excludes []*regexp.Regexp
 
-	if Exclude != "" {
-		regex = regexp.MustCompile(Exclude)
+	for _, exclude := range Exclude {
+		excludes = append(excludes, regexp.MustCompile(exclude))
 	}
 
 	var fpath string
@@ -124,12 +124,13 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 				}
 			}
 
-			if Exclude != "" {
-				if regex.Match([]byte(f.Name())) {
+			for _, exclude := range excludes {
+				if exclude.Match([]byte(f.Name())) {
 					if Verbose {
 						printWarn("skipping directory due to match exclude: " + f.Name())
 					}
 					shouldSkip = true
+					break
 				}
 			}
 
@@ -177,12 +178,13 @@ func walkDirectoryParallel(root string, output chan *FileJob) {
 				shouldSkip = true
 			}
 
-			if Exclude != "" {
-				if regex.Match([]byte(f.Name())) {
+			for _, exclude := range excludes {
+				if exclude.Match([]byte(f.Name())) {
 					if Verbose {
 						printWarn("skipping file due to match exclude: " + f.Name())
 					}
 					shouldSkip = true
+					break
 				}
 			}
 
@@ -228,9 +230,10 @@ func walkDirectory(toWalk string, blackList []string, extensionLookup map[string
 	extension := ""
 	var filejobs []FileJob
 
-	var regex *regexp.Regexp
-	if Exclude != "" {
-		regex = regexp.MustCompile(Exclude)
+	var excludes []*regexp.Regexp
+
+	for _, exclude := range Exclude {
+		excludes = append(excludes, regexp.MustCompile(exclude))
 	}
 
 	_ = godirwalk.Walk(toWalk, &godirwalk.Options{
@@ -238,8 +241,8 @@ func walkDirectory(toWalk string, blackList []string, extensionLookup map[string
 		Unsorted: true,
 		Callback: func(root string, info *godirwalk.Dirent) error {
 
-			if Exclude != "" {
-				if regex.Match([]byte(info.Name())) {
+			for _, exclude := range excludes {
+				if exclude.Match([]byte(info.Name())) {
 					if Verbose {
 						if info.IsDir() {
 							printWarn("skipping directory due to match exclude: " + root)

--- a/processor/file_test.go
+++ b/processor/file_test.go
@@ -74,7 +74,7 @@ func TestWalkDirectoryParallel(t *testing.T) {
 	ProcessConstants()
 
 	WhiteListExtensions = []string{"go"}
-	Exclude = "vendor"
+	Exclude = []string{"vendor"}
 	PathBlacklist = []string{"vendor"}
 	Verbose = true
 	Trace = true
@@ -100,7 +100,7 @@ func TestWalkDirectoryParallelWorksWithSingleInputFile(t *testing.T) {
 	ProcessConstants()
 
 	WhiteListExtensions = []string{"go"}
-	Exclude = "vendor"
+	Exclude = []string{"vendor"}
 	PathBlacklist = []string{"vendor"}
 	Verbose = true
 	Trace = true
@@ -126,7 +126,7 @@ func TestWalkDirectoryParallelIgnoresRootTrailingSlash(t *testing.T) {
 	ProcessConstants()
 
 	WhiteListExtensions = []string{"go"}
-	Exclude = "vendor"
+	Exclude = []string{"vendor"}
 	PathBlacklist = []string{"vendor"}
 	Verbose = true
 	Trace = true
@@ -149,7 +149,7 @@ func TestWalkDirectoryParallelIgnoresRootTrailingSlash(t *testing.T) {
 
 func TestWalkDirectory(t *testing.T) {
 	Debug = true
-	Exclude = "test"
+	Exclude = []string{"test"}
 	ProcessConstants()
 	files := walkDirectory(".", []string{}, ExtensionToLanguage)
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -50,7 +50,7 @@ var DisableCheckBinary = false
 var SortBy = ""
 
 // Exclude is a regular expression which is used to exclude files from being processed
-var Exclude = ""
+var Exclude = []string{}
 
 // Format sets the output format of the formatter
 var Format = ""


### PR DESCRIPTION
This is to address #67. It changes the `--not-match` argument to a `StringArray` to allow multiple exclusions to be passed.

I used `StringArray` rather than `StringSlice` since the latter splits on commas, and while I disapprove of commas in file names I think it's better to be tolerant. Besides, comma separating regular expressions could get ugly.