### PR TITLE
Add test case and temp fix for issue72

### DIFF
--- a/processor/workers.go
+++ b/processor/workers.go
@@ -301,7 +301,18 @@ func CountStats(fileJob *FileJob) {
 		digest = md5.New()
 	}
 
-	for index := 0; index < len(fileJob.Content); index++ {
+	// Index starts at 0 unless we have BOM in which case we want to skip it
+	// Check if BOM exists and if so remove it
+	start := 0
+
+	if fileJob.Bytes >= 3 {
+		if fileJob.Content[0] == 239 && fileJob.Content[1] == 187 && fileJob.Content[2] == 191 {
+			// BOM exists set the start to skip over it
+			start = 3
+		}
+	}
+
+	for index := start; index < len(fileJob.Content); index++ {
 
 		// Based on our current state determine if the state should change by checking
 		// what the character is. The below is very CPU bound so need to be careful if

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -34,7 +34,7 @@ const (
 	LINE_COMMENT
 )
 
-// Taken from Thttps://en.wikipedia.org/wiki/Byte_order_mark#Byte_order_marks_by_encoding
+// Taken from https://en.wikipedia.org/wiki/Byte_order_mark#Byte_order_marks_by_encoding
 var ByteOrderMarks = [][]byte{
 	{239, 187, 191},       // UTF-8 make this first as it is likely to be the most common case
 	{254, 255},            // UTF-16 BE

--- a/processor/workers_regression_test.go
+++ b/processor/workers_regression_test.go
@@ -6,14 +6,11 @@ import "testing"
 // Turns out the above is due to BOM being present for that file
 func TestCountStatsIssue72(t *testing.T) {
 	ProcessConstants()
+	fileJob := FileJob{
+		Language: "C#",
+	}
 
-	// Try out every since BOM that we are aware of
-	for _, v := range ByteOrderMarks {
-		fileJob := FileJob{
-			Language: "C#",
-		}
-
-		fileJob.Content = append(v, []byte(`// Comment 1
+	fileJob.Content = []byte(`   // Comment 1
 namespace Baz
 {
     using System;
@@ -26,24 +23,28 @@ namespace Baz
           throw new NotImplementedException();
         }
     }
-}`)...)
+}`)
 
-		CountStats(&fileJob)
+	// Set the BOM
+	fileJob.Content[0] = 239
+	fileJob.Content[1] = 187
+	fileJob.Content[2] = 191
 
-		if fileJob.Lines != 14 {
-			t.Errorf("Expected 14 lines")
-		}
+	CountStats(&fileJob)
 
-		if fileJob.Code != 11 {
-			t.Errorf("Expected 11 lines got %d", fileJob.Code)
-		}
+	if fileJob.Lines != 14 {
+		t.Errorf("Expected 14 lines")
+	}
 
-		if fileJob.Comment != 2 {
-			t.Errorf("Expected 2 lines got %d", fileJob.Comment)
-		}
+	if fileJob.Code != 11 {
+		t.Errorf("Expected 11 lines got %d", fileJob.Code)
+	}
 
-		if fileJob.Blank != 1 {
-			t.Errorf("Expected 1 lines got %d", fileJob.Blank)
-		}
+	if fileJob.Comment != 2 {
+		t.Errorf("Expected 2 lines got %d", fileJob.Comment)
+	}
+
+	if fileJob.Blank != 1 {
+		t.Errorf("Expected 1 lines got %d", fileJob.Blank)
 	}
 }

--- a/processor/workers_regression_test.go
+++ b/processor/workers_regression_test.go
@@ -6,11 +6,14 @@ import "testing"
 // Turns out the above is due to BOM being present for that file
 func TestCountStatsIssue72(t *testing.T) {
 	ProcessConstants()
-	fileJob := FileJob{
-		Language: "C#",
-	}
 
-	fileJob.Content = []byte(`   // Comment 1
+	// Try out every since BOM that we are aware of
+	for _, v := range ByteOrderMarks {
+		fileJob := FileJob{
+			Language: "C#",
+		}
+
+		fileJob.Content = append(v, []byte(`// Comment 1
 namespace Baz
 {
     using System;
@@ -23,28 +26,24 @@ namespace Baz
           throw new NotImplementedException();
         }
     }
-}`)
+}`)...)
 
-	// Set the BOM
-	fileJob.Content[0] = 239
-	fileJob.Content[1] = 187
-	fileJob.Content[2] = 191
+		CountStats(&fileJob)
 
-	CountStats(&fileJob)
+		if fileJob.Lines != 14 {
+			t.Errorf("Expected 14 lines")
+		}
 
-	if fileJob.Lines != 14 {
-		t.Errorf("Expected 14 lines")
-	}
+		if fileJob.Code != 11 {
+			t.Errorf("Expected 11 lines got %d", fileJob.Code)
+		}
 
-	if fileJob.Code != 11 {
-		t.Errorf("Expected 11 lines got %d", fileJob.Code)
-	}
+		if fileJob.Comment != 2 {
+			t.Errorf("Expected 2 lines got %d", fileJob.Comment)
+		}
 
-	if fileJob.Comment != 2 {
-		t.Errorf("Expected 2 lines got %d", fileJob.Comment)
-	}
-
-	if fileJob.Blank != 1 {
-		t.Errorf("Expected 1 lines got %d", fileJob.Blank)
+		if fileJob.Blank != 1 {
+			t.Errorf("Expected 1 lines got %d", fileJob.Blank)
+		}
 	}
 }

--- a/processor/workers_regression_test.go
+++ b/processor/workers_regression_test.go
@@ -1,0 +1,50 @@
+package processor
+
+import "testing"
+
+// https://github.com/boyter/scc/issues/72
+// Turns out the above is due to BOM being present for that file
+func TestCountStatsIssue72(t *testing.T) {
+	ProcessConstants()
+	fileJob := FileJob{
+		Language: "C#",
+	}
+
+	fileJob.Content = []byte(`   // Comment 1
+namespace Baz
+{
+    using System;
+
+    public class FooClass
+    {
+        public void Test(string report)
+        {
+          // Comment 2
+          throw new NotImplementedException();
+        }
+    }
+}`)
+
+	// Set the BOM
+	fileJob.Content[0] = 239
+	fileJob.Content[1] = 187
+	fileJob.Content[2] = 191
+
+	CountStats(&fileJob)
+
+	if fileJob.Lines != 14 {
+		t.Errorf("Expected 14 lines")
+	}
+
+	if fileJob.Code != 11 {
+		t.Errorf("Expected 11 lines got %d", fileJob.Code)
+	}
+
+	if fileJob.Comment != 2 {
+		t.Errorf("Expected 2 lines got %d", fileJob.Comment)
+	}
+
+	if fileJob.Blank != 1 {
+		t.Errorf("Expected 1 lines got %d", fileJob.Blank)
+	}
+}

--- a/processor/workers_test.go
+++ b/processor/workers_test.go
@@ -808,6 +808,20 @@ func TestGuessLanguageLanguageEmptyContent(t *testing.T) {
 	}
 }
 
+func TestCheckBomSkip(t *testing.T) {
+	for _, v := range ByteOrderMarks {
+		fileJob := &FileJob{
+			Content: v,
+		}
+
+		skip := checkBomSkip(fileJob)
+
+		if skip != len(v) {
+			t.Errorf("Expected skip length to match %d got %d", len(v), skip)
+		}
+	}
+}
+
 //////////////////////////////////////////////////
 // Benchmarks Below
 //////////////////////////////////////////////////

--- a/processor/workers_test.go
+++ b/processor/workers_test.go
@@ -809,6 +809,7 @@ func TestGuessLanguageLanguageEmptyContent(t *testing.T) {
 }
 
 func TestCheckBomSkip(t *testing.T) {
+	Verbose = true
 	for _, v := range ByteOrderMarks {
 		fileJob := &FileJob{
 			Content: v,

--- a/processor/workers_test.go
+++ b/processor/workers_test.go
@@ -808,6 +808,17 @@ func TestGuessLanguageLanguageEmptyContent(t *testing.T) {
 	}
 }
 
+func TestCheckBomSkipUTF8(t *testing.T) {
+	fileJob := &FileJob{
+		Content: []byte{239, 187, 191}, // UTF-8 BOM
+	}
+
+	skip := checkBomSkip(fileJob)
+	if skip != 3 {
+		t.Errorf("Expected skip length to match 3 got %d", skip)
+	}
+}
+
 func TestCheckBomSkip(t *testing.T) {
 	Verbose = true
 	for _, v := range ByteOrderMarks {
@@ -816,8 +827,7 @@ func TestCheckBomSkip(t *testing.T) {
 		}
 
 		skip := checkBomSkip(fileJob)
-
-		if skip != len(v) {
+		if skip != 0 {
 			t.Errorf("Expected skip length to match %d got %d", len(v), skip)
 		}
 	}


### PR DESCRIPTION
Don't actually want to merge this yet, as I belive the solution should be more generic but this does work to fix the issue in https://github.com/boyter/scc/issues/72

I am thinking that perhaps the full table of BOM https://en.wikipedia.org/wiki/Byte_order_mark#Byte_order_marks_by_encoding should be included in this to ensure that it works for all encoding types. No idea what impact that would have though. Is it even worth doing it for all of them?

Looking for ideas on this before it gets merged in for good to ensure its a solution that does not need to be revisited if possible.