### PR TITLE
Resolve issue73 where quotes in character would trigger string state

### DIFF
--- a/processor/workers.go
+++ b/processor/workers.go
@@ -142,7 +142,12 @@ func codeState(
 
 			switch tokenType, offsetJump, endString := langFeatures.Tokens.Match(fileJob.Content[i:]); tokenType {
 			case TString:
-				currentState = SString
+				// It is safe to -1 here as to enter the code state we need to have
+				// transitioned from blank to here hence i should always be >= 1
+				// This check is to ensure we aren't in a character declaration
+				if fileJob.Content[i-1] != '\\' {
+					currentState = SString
+				}
 				return i, currentState, endString, endComments
 
 			case TSlcomment:

--- a/processor/workers_test.go
+++ b/processor/workers_test.go
@@ -808,6 +808,38 @@ func TestGuessLanguageLanguageEmptyContent(t *testing.T) {
 	}
 }
 
+// Captures checking if a quote is prefixed by \ such as in
+// a char which should otherwise trigger the string state which is incorrect
+func TestCountStatsIssue73(t *testing.T) {
+	ProcessConstants()
+	fileJob := FileJob{
+		Language: "Java",
+	}
+
+	fileJob.Content = []byte(`'\"'{
+code
+
+`)
+
+	CountStats(&fileJob)
+
+	if fileJob.Lines != 3 {
+		t.Errorf("Expected 3 lines")
+	}
+
+	if fileJob.Code != 2 {
+		t.Errorf("Expected 2 lines got %d", fileJob.Code)
+	}
+
+	if fileJob.Comment != 0 {
+		t.Errorf("Expected 0 lines got %d", fileJob.Comment)
+	}
+
+	if fileJob.Blank != 1 {
+		t.Errorf("Expected 1 lines got %d", fileJob.Blank)
+	}
+}
+
 //////////////////////////////////////////////////
 // Benchmarks Below
 //////////////////////////////////////////////////


### PR DESCRIPTION
A fix for https://github.com/boyter/scc/issues/73

If a " was used inside a character it would trigger the string state. Quick fix is to check for \ before it and stay in the code state. 

Long term fix is to have a state for dealing with quotes, perhaps inside strings as they have the same rules. However this requires updating the whole JSON document and checking that quotes work like strings in all languages (unlikely). This seems like a good reasonable short term fix for most C like languages.