### PR TITLE
rename the option that disables cocomo from '--cocomo' to '--no-cocomo'

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ Flags:
       --binary                  disable binary file detection
       --by-file                 display output for every file
       --ci                      enable CI output settings where stdout is ASCII
-      --cocomo                  remove COCOMO calculation output
       --debug                   enable debug output
       --exclude-dir strings     directories to exclude (default [.git,.hg,.svn])
       --file-gc-count int       number of files to parse before turning the GC on (default 10000)
@@ -107,6 +106,7 @@ Flags:
   -h, --help                    help for scc
   -i, --include-ext strings     limit to file extensions [comma separated list: e.g. go,java,js]
   -l, --languages               print supported languages and extensions
+      --no-cocomo               remove COCOMO calculation output
   -c, --no-complexity           skip calculation of code complexity
   -d, --no-duplicates           remove duplicate files from stats and output
       --no-gitignore            disables .gitignore file logic

--- a/main.go
+++ b/main.go
@@ -46,12 +46,6 @@ func main() {
 		"display output for every file",
 	)
 	flags.BoolVar(
-		&processor.Cocomo,
-		"cocomo",
-		false,
-		"remove COCOMO calculation output",
-	)
-	flags.BoolVar(
 		&processor.Ci,
 		"ci",
 		false,
@@ -107,6 +101,12 @@ func main() {
 		"l",
 		false,
 		"print supported languages and extensions",
+	)
+	flags.BoolVar(
+		&processor.Cocomo,
+		"no-cocomo",
+		false,
+		"remove COCOMO calculation output",
 	)
 	flags.BoolVarP(
 		&processor.Complexity,

--- a/test-all.sh
+++ b/test-all.sh
@@ -103,7 +103,7 @@ else
     exit
 fi
 
-if ./scc --avg-wage 10000 --binary --by-file --cocomo --debug --exclude-dir .git -f tabular -i go -c -d -M something -s name -w processor > /dev/null ; then
+if ./scc --avg-wage 10000 --binary --by-file --no-cocomo --debug --exclude-dir .git -f tabular -i go -c -d -M something -s name -w processor > /dev/null ; then
     echo -e "${GREEN}PASSED multiple options test"
 else
     echo -e "${RED}======================================================="


### PR DESCRIPTION
The naming of this option is unintuitive - it disables cocomo, but is named as if it would enable cocomo. Renaming it to be in line with the similar `--no-complexity`, `--no-gitignore`, etc.

```
$ GOPATH=~/code ./test-all.sh 
Running go fmt...
Running unit tests...
?   	github.com/boyter/scc	[no test files]
?   	github.com/boyter/scc/examples/language	[no test files]
ok  	github.com/boyter/scc/processor	1.137s
?   	github.com/boyter/scc/scripts	[no test files]
Building application...
Running integration tests...
Error: unknown flag: --not-a-real-option
Usage:
  scc [flags]

Flags:
      --avg-wage int            average wage value used for basic COCOMO calculation (default 56286)
      --binary                  disable binary file detection
      --by-file                 display output for every file
      --ci                      enable CI output settings where stdout is ASCII
      --debug                   enable debug output
      --exclude-dir strings     directories to exclude (default [.git,.hg,.svn])
      --file-gc-count int       number of files to parse before turning the GC on (default 10000)
  -f, --format string           set output format [tabular, wide, json, csv, cloc-yaml] (default "tabular")
  -h, --help                    help for scc
  -i, --include-ext strings     limit to file extensions [comma separated list: e.g. go,java,js]
  -l, --languages               print supported languages and extensions
      --no-cocomo               remove COCOMO calculation output
  -c, --no-complexity           skip calculation of code complexity
  -d, --no-duplicates           remove duplicate files from stats and output
      --no-gitignore            disables .gitignore file logic
      --no-ignore               disables .ignore file logic
  -M, --not-match stringArray   ignore files and directories matching regular expression
  -o, --output string           output filename (default stdout)
  -s, --sort string             column to sort by [files, name, lines, blanks, code, comments, complexity] (default "files")
  -t, --trace                   enable trace output. Not recommended when processing multiple files
  -v, --verbose                 verbose output
      --version                 version for scc
  -w, --wide                    wider output with additional statistics (implies --complexity)

PASSED invalid option test
<stdin>:4: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
PASSED cloc-yaml format test
<stdin>:4: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
PASSED cloc-yml format test
PASSED invalid file/directory test
PASSED no directory specified test
PASSED directory specified test
PASSED multiple options test
PASSED regular expression ignore test
PASSED shared extension test 1
PASSED shared extension test 2
PASSED shared extension test 3
PASSED ci param test
PASSED concurrency issue test
PASSED file specified test
PASSED multiple file argument test 1
PASSED multiple file argument test 2
PASSED multiple directory specified test
PASSED ignore file directory check
PASSED duplicates test
PASSED deterministic test
PASSED multiple regex test
PASSED git filter
PASSED git ignore filter
PASSED ignore filter
PASSED multiple gitignore
PASSED ignore recursive filter
PASSED gitignore recursive filter
PASSED Bosque  Language Check
PASSED Flow9  Language Check
PASSED Bitbucket Pipeline  Language Check
PASSED Docker ignore  Language Check
PASSED Q#  Language Check
PASSED Futhark  Language Check
PASSED Alloy  Language Check
PASSED Wren  Language Check
PASSED Monkey C  Language Check
PASSED Alchemist  Language Check
PASSED Luna  Language Check
PASSED ignore  Language Check
PASSED XML Schema  Language Check
PASSED Web Services Language Check
PASSED Go  Language Check
PASSED Java  Language Check
Cleaning up...
=================================================
ALL TESTS PASSED
=================================================
```