### PR TITLE
reorder fields in tabular output to match cloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,35 +125,36 @@ Output should look something like the below for the redis project
 ```
 $ scc .
 ───────────────────────────────────────────────────────────────────────────────
-Language                 Files     Lines     Code  Comments   Blanks Complexity
+Language                 Files     Lines   Blanks  Comments     Code Complexity
 ───────────────────────────────────────────────────────────────────────────────
-C                          249    143701   103269     24163    16269      25906
-C Header                   199     27537    18543      5768     3226       1557
-TCL                         98     16865    14098       954     1813       1404
-Shell                       36      1106      775       215      116         89
-Lua                         20       525      387        70       68         65
-Autoconf                    18     10821     8469      1326     1026        951
-gitignore                   11       151      135         0       16          0
-Makefile                     9      1031      722       100      209         50
-Markdown                     8      1886     1363         0      523          0
-Ruby                         8       722      580        69       73        107
-HTML                         5      9658     8791        12      855          0
-C++                          5       311      244        16       51         31
-YAML                         4       273      254         0       19          0
-License                      3        66       55         0       11          0
-CSS                          2       107       91         0       16          0
-Python                       2       219      162        18       39         68
-C++ Header                   1         9        5         3        1          0
-Smarty Template              1        44       43         0        1          5
-m4                           1       562      393        53      116          0
-Plain Text                   1        23       16         0        7          0
-Batch                        1        28       26         0        2          3
+C                          258    153080    17005     26121   109954      27671
+C Header                   200     28794     3252      5877    19665       1557
+TCL                        101     17802     1879       981    14942       1439
+Shell                       36      1109      133       252      724        118
+Lua                         20       525       68        70      387         65
+Autoconf                    18     10821     1026      1326     8469        951
+Makefile                    10      1082      220       103      759         51
+Ruby                        10       778       78        71      629        115
+Markdown                     9      1935      527         0     1408          0
+gitignore                    9       120       16         0      104          0
+HTML                         5      9658     2928        12     6718          0
+C++                          4       286       48        14      224         31
+License                      4       100       20         0       80          0
+YAML                         4       266       20         3      243          0
+CSS                          2       107       16         0       91          0
+Python                       2       219       39        18      162         68
+Batch                        1        28        2         0       26          3
+C++ Header                   1         9        1         3        5          0
+Extensible Styleshe…         1        10        0         0       10          0
+Plain Text                   1        23        7         0       16          0
+Smarty Template              1        44        1         0       43          5
+m4                           1       562      116        53      393          0
 ───────────────────────────────────────────────────────────────────────────────
-Total                      682    215645   158421     32767    24457      30236
+Total                      698    227358    27402     34904   165052      32074
 ───────────────────────────────────────────────────────────────────────────────
-Estimated Cost to Develop $5,513,136
-Estimated Schedule Effort 29.350958 months
-Estimated People Required 22.250054
+Estimated Cost to Develop $5,755,686
+Estimated Schedule Effort 29.835114 months
+Estimated People Required 22.851995
 ───────────────────────────────────────────────────────────────────────────────
 ```
 
@@ -246,11 +247,15 @@ Some CI/CD systems which will remain nameless do not work very well with the box
 ```
 $ scc --ci main.go
 -------------------------------------------------------------------------------
-Language                 Files     Lines     Code  Comments   Blanks Complexity
+Language                 Files     Lines   Blanks  Comments     Code Complexity
 -------------------------------------------------------------------------------
-Go                           1       171      161         4        6          2
+Go                           1       171        6         4      161          2
 -------------------------------------------------------------------------------
-Total                        1       171      161         4        6          2
+Total                        1       171        6         4      161          2
+-------------------------------------------------------------------------------
+Estimated Cost to Develop $3,969
+Estimated Schedule Effort 1.876811 months
+Estimated People Required 0.250551
 -------------------------------------------------------------------------------
 ```
 

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -22,9 +22,9 @@ var tabularShortFormatFile = "%-30s %9d %8d %9d %8d %10d\n"
 var shortFormatFileTrucate = 29
 var shortNameTruncate = 20
 
-var tabularShortFormatHeadNoComplexity = "%-22s %11s %11s %9s %11s %10s\n"
-var tabularShortFormatBodyNoComplexity = "%-22s %11d %11d %9d %11d %10d\n"
-var tabularShortFormatFileNoComplexity = "%-34s %11d %9d %11d %10d\n"
+var tabularShortFormatHeadNoComplexity = "%-22s %11s %11s %10s %11s %9s\n"
+var tabularShortFormatBodyNoComplexity = "%-22s %11d %11d %10d %11d %9d\n"
+var tabularShortFormatFileNoComplexity = "%-34s %11d %10d %11d %9d\n"
 var shortFormatFileTrucateNoComplexity = 33
 var longNameTruncate = 22
 
@@ -302,7 +302,7 @@ func fileSummarizeLong(input chan *FileJob) string {
 	var str strings.Builder
 
 	str.WriteString(getTabularWideBreak())
-	str.WriteString(fmt.Sprintf(tabularWideFormatHead, "Language", "Files", "Lines", "Code", "Comments", "Blanks", "Complexity", "Complexity/Lines"))
+	str.WriteString(fmt.Sprintf(tabularWideFormatHead, "Language", "Files", "Lines", "Blanks", "Comments", "Code", "Complexity", "Complexity/Lines"))
 
 	if !Files {
 		str.WriteString(getTabularWideBreak())
@@ -411,7 +411,7 @@ func fileSummarizeLong(input chan *FileJob) string {
 			trimmedName = summary.Name[:longNameTruncate-1] + "…"
 		}
 
-		str.WriteString(fmt.Sprintf(tabularWideFormatBody, trimmedName, summary.Count, summary.Lines, summary.Code, summary.Comment, summary.Blank, summary.Complexity, summary.WeightedComplexity))
+		str.WriteString(fmt.Sprintf(tabularWideFormatBody, trimmedName, summary.Count, summary.Lines, summary.Blank, summary.Comment, summary.Code, summary.Complexity, summary.WeightedComplexity))
 
 		if Files {
 			sortSummaryFiles(&summary)
@@ -425,7 +425,7 @@ func fileSummarizeLong(input chan *FileJob) string {
 					tmp = "~" + tmp[totrim:]
 				}
 
-				str.WriteString(fmt.Sprintf(tabularWideFormatFile, tmp, res.Lines, res.Code, res.Comment, res.Blank, res.Complexity, res.WeightedComplexity))
+				str.WriteString(fmt.Sprintf(tabularWideFormatFile, tmp, res.Lines, res.Blank, res.Comment, res.Code, res.Complexity, res.WeightedComplexity))
 			}
 		}
 	}
@@ -435,7 +435,7 @@ func fileSummarizeLong(input chan *FileJob) string {
 	}
 
 	str.WriteString(getTabularWideBreak())
-	str.WriteString(fmt.Sprintf(tabularWideFormatBody, "Total", sumFiles, sumLines, sumCode, sumComment, sumBlank, sumComplexity, sumWeightedComplexity))
+	str.WriteString(fmt.Sprintf(tabularWideFormatBody, "Total", sumFiles, sumLines, sumBlank, sumComment, sumCode, sumComplexity, sumWeightedComplexity))
 	str.WriteString(getTabularWideBreak())
 
 	if !Cocomo {
@@ -460,9 +460,9 @@ func fileSummarizeShort(input chan *FileJob) string {
 
 	str.WriteString(getTabularShortBreak())
 	if !Complexity {
-		str.WriteString(fmt.Sprintf(tabularShortFormatHead, "Language", "Files", "Lines", "Code", "Comments", "Blanks", "Complexity"))
+		str.WriteString(fmt.Sprintf(tabularShortFormatHead, "Language", "Files", "Lines", "Blanks", "Comments", "Code", "Complexity"))
 	} else {
-		str.WriteString(fmt.Sprintf(tabularShortFormatHeadNoComplexity, "Language", "Files", "Lines", "Code", "Comments", "Blanks"))
+		str.WriteString(fmt.Sprintf(tabularShortFormatHeadNoComplexity, "Language", "Files", "Lines", "Blanks", "Comments", "Code"))
 	}
 
 	if !Files {
@@ -530,9 +530,9 @@ func fileSummarizeShort(input chan *FileJob) string {
 		trimmedName = trimNameShort(summary, trimmedName)
 
 		if !Complexity {
-			str.WriteString(fmt.Sprintf(tabularShortFormatBody, trimmedName, summary.Count, summary.Lines, summary.Code, summary.Comment, summary.Blank, summary.Complexity))
+			str.WriteString(fmt.Sprintf(tabularShortFormatBody, trimmedName, summary.Count, summary.Lines, summary.Blank, summary.Comment, summary.Code, summary.Complexity))
 		} else {
-			str.WriteString(fmt.Sprintf(tabularShortFormatBodyNoComplexity, trimmedName, summary.Count, summary.Lines, summary.Code, summary.Comment, summary.Blank))
+			str.WriteString(fmt.Sprintf(tabularShortFormatBodyNoComplexity, trimmedName, summary.Count, summary.Lines, summary.Blank, summary.Comment, summary.Code))
 		}
 
 		if Files {
@@ -548,9 +548,9 @@ func fileSummarizeShort(input chan *FileJob) string {
 				}
 
 				if !Complexity {
-					str.WriteString(fmt.Sprintf(tabularShortFormatFile, tmp, res.Lines, res.Code, res.Comment, res.Blank, res.Complexity))
+					str.WriteString(fmt.Sprintf(tabularShortFormatFile, tmp, res.Lines, res.Blank, res.Comment, res.Code, res.Complexity))
 				} else {
-					str.WriteString(fmt.Sprintf(tabularShortFormatFileNoComplexity, tmp, res.Lines, res.Code, res.Comment, res.Blank))
+					str.WriteString(fmt.Sprintf(tabularShortFormatFileNoComplexity, tmp, res.Lines, res.Blank, res.Comment, res.Code))
 				}
 			}
 		}
@@ -562,9 +562,9 @@ func fileSummarizeShort(input chan *FileJob) string {
 
 	str.WriteString(getTabularShortBreak())
 	if !Complexity {
-		str.WriteString(fmt.Sprintf(tabularShortFormatBody, "Total", sumFiles, sumLines, sumCode, sumComment, sumBlank, sumComplexity))
+		str.WriteString(fmt.Sprintf(tabularShortFormatBody, "Total", sumFiles, sumLines, sumBlank, sumComment, sumCode, sumComplexity))
 	} else {
-		str.WriteString(fmt.Sprintf(tabularShortFormatBodyNoComplexity, "Total", sumFiles, sumLines, sumCode, sumComment, sumBlank))
+		str.WriteString(fmt.Sprintf(tabularShortFormatBodyNoComplexity, "Total", sumFiles, sumLines, sumBlank, sumComment, sumCode))
 	}
 	str.WriteString(getTabularShortBreak())
 


### PR DESCRIPTION
This came out simpler than expected because:
1. "reordering" only meant swapping the Blanks and Code columns. 
2. Only the tabularShortFormatNoComplexity format strings needed to be updated; Blanks and Code shared the same formatting directives in tabularShortFormat/tabularWideFormat modes.

I made a gist with output from each of the three formats running on the old version of scc, then edited them with output of each of the three formats from the new scc - the revision view shows a nice diff between the outputs:

https://gist.github.com/elindsey/a55888e1908789410967b92dfc57ded9/revisions
https://gist.github.com/elindsey/bfaa08a2dc3f77d253cb831f4d1fe3bf/revisions
https://gist.github.com/elindsey/357c48c798214f6613e1da6d038aa855/revisions

Test output follows:
```
$ GOPATH=~/code ./test-all.sh 
Running go fmt...
Running unit tests...
?   	github.com/boyter/scc	[no test files]
?   	github.com/boyter/scc/examples/language	[no test files]
ok  	github.com/boyter/scc/processor	1.138s
?   	github.com/boyter/scc/scripts	[no test files]
Building application...
Running integration tests...
Error: unknown flag: --not-a-real-option
Usage:
  scc [flags]

Flags:
      --avg-wage int            average wage value used for basic COCOMO calculation (default 56286)
      --binary                  disable binary file detection
      --by-file                 display output for every file
      --ci                      enable CI output settings where stdout is ASCII
      --debug                   enable debug output
      --exclude-dir strings     directories to exclude (default [.git,.hg,.svn])
      --file-gc-count int       number of files to parse before turning the GC on (default 10000)
  -f, --format string           set output format [tabular, wide, json, csv, cloc-yaml] (default "tabular")
  -h, --help                    help for scc
  -i, --include-ext strings     limit to file extensions [comma separated list: e.g. go,java,js]
  -l, --languages               print supported languages and extensions
      --no-cocomo               remove COCOMO calculation output
  -c, --no-complexity           skip calculation of code complexity
  -d, --no-duplicates           remove duplicate files from stats and output
      --no-gitignore            disables .gitignore file logic
      --no-ignore               disables .ignore file logic
  -M, --not-match stringArray   ignore files and directories matching regular expression
  -o, --output string           output filename (default stdout)
  -s, --sort string             column to sort by [files, name, lines, blanks, code, comments, complexity] (default "files")
  -t, --trace                   enable trace output. Not recommended when processing multiple files
  -v, --verbose                 verbose output
      --version                 version for scc
  -w, --wide                    wider output with additional statistics (implies --complexity)

PASSED invalid option test
<stdin>:4: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
PASSED cloc-yaml format test
<stdin>:4: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
PASSED cloc-yml format test
PASSED invalid file/directory test
PASSED no directory specified test
PASSED directory specified test
PASSED multiple options test
PASSED regular expression ignore test
PASSED shared extension test 1
PASSED shared extension test 2
PASSED shared extension test 3
PASSED ci param test
PASSED concurrency issue test
PASSED file specified test
PASSED multiple file argument test 1
PASSED multiple file argument test 2
PASSED multiple directory specified test
PASSED ignore file directory check
PASSED duplicates test
PASSED deterministic test
PASSED multiple regex test
PASSED git filter
PASSED git ignore filter
PASSED ignore filter
PASSED multiple gitignore
PASSED ignore recursive filter
PASSED gitignore recursive filter
PASSED Bosque  Language Check
PASSED Flow9  Language Check
PASSED Bitbucket Pipeline  Language Check
PASSED Docker ignore  Language Check
PASSED Q#  Language Check
PASSED Futhark  Language Check
PASSED Alloy  Language Check
PASSED Wren  Language Check
PASSED Monkey C  Language Check
PASSED Alchemist  Language Check
PASSED Luna  Language Check
PASSED ignore  Language Check
PASSED XML Schema  Language Check
PASSED Web Services Language Check
PASSED Go  Language Check
PASSED Java  Language Check
Cleaning up...
=================================================
ALL TESTS PASSED
=================================================
```