### PR TITLE
add homebrew to install docs; rearrange install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,29 @@ Dual-licensed under MIT or the [UNLICENSE](http://unlicense.org).
 
 ### Install
 
-If you are comfortable using Go and have >= 1.10 installed the usual `go get -u github.com/boyter/scc/` will install for you.
+#### Go Get
 
-If you are looking for binaries see [Releases](https://github.com/boyter/scc/releases) for Windows, GNU/Linux and macOS for both i386 and x86_64 bit machines.
+If you are comfortable using Go and have >= 1.10 installed:
 
-A snap install exists https://snapcraft.io/scc thanks to [Ricardo](https://feliciano.tech/). You can run `sudo snap install scc` to install it.
+`$ go get -u github.com/boyter/scc/`
 
-If you would like to assist with getting `scc` added into apt/homebrew/chocolatey/etc... please submit a PR or at least raise an issue with instructions.
+#### Snap
+
+A [snap install](https://snapcraft.io/scc) exists thanks to [Ricardo](https://feliciano.tech/).
+
+`$ sudo snap install scc`
+
+#### Homebrew
+
+`$ brew install scc`
+
+#### Manual
+
+Binaries for Windows, GNU/Linux and macOS for both i386 and x86_64 machines are available from the [releases](https://github.com/boyter/scc/releases) page.
+
+#### Other
+
+If you would like to assist with getting `scc` added into apt/chocolatey/etc... please submit a PR or at least raise an issue with instructions.
 
 ### Background
 


### PR DESCRIPTION
I added homebrew to the install docs. They were starting to get long, so I rearranged it a bit - let me know if you don't like the restructuring and I'll just tack it on to the existing text instead.

Might be easier to read the formatted version here https://github.com/elindsey/scc/tree/bmaster