### PR TITLE
Reduce dir handles

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "github.com/dbaggerman/cuba"
   packages = ["."]
-  revision = "5acd70297eb479db756c8e2314f8ac896be61f8d"
-  version = "v0.3.1"
+  revision = "eea065551ffcf98105d83bfc624d5ecbf4dd0ea9"
+  version = "v0.3.2"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -65,6 +65,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5490b7099ab27ebb1836a10b2288c5815ffae5b55369038d899a8e3642a0d48d"
+  inputs-digest = "73ffb2cf1749b60052c384c47e69ba298d082a556c596996a0eaf425b63eebad"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,5 +35,5 @@
 
 [[constraint]]
   name = "github.com/dbaggerman/cuba"
-  version = "0.3.1"
+  version = "0.3.2"
 

--- a/processor/file_test.go
+++ b/processor/file_test.go
@@ -87,9 +87,9 @@ func TestWalkDirectoryParallel(t *testing.T) {
 	inputChan := make(chan *FileJob, 10000)
 
 	dirwalker := NewDirectoryWalker(inputChan)
-	err := dirwalker.Walk("../")
+	err := dirwalker.Start("../")
 	if err != nil {
-		t.Errorf("dirwalker.Walk returned error: %v", err)
+		t.Errorf("dirwalker.Start returned error: %v", err)
 		t.FailNow()
 	}
 	dirwalker.Run()
@@ -119,9 +119,9 @@ func TestWalkDirectoryParallelWorksWithSingleInputFile(t *testing.T) {
 	inputChan := make(chan *FileJob, 10000)
 
 	dirwalker := NewDirectoryWalker(inputChan)
-	err := dirwalker.Walk("file_test.go")
+	err := dirwalker.Start("file_test.go")
 	if err != nil {
-		t.Errorf("dirwalker.Walk returned error: %v", err)
+		t.Errorf("dirwalker.Start returned error: %v", err)
 		t.FailNow()
 	}
 	dirwalker.Run()
@@ -151,9 +151,9 @@ func TestWalkDirectoryParallelIgnoresRootTrailingSlash(t *testing.T) {
 	inputChan := make(chan *FileJob, 10000)
 
 	dirwalker := NewDirectoryWalker(inputChan)
-	err := dirwalker.Walk("file_test.go/")
+	err := dirwalker.Start("file_test.go/")
 	if err != nil {
-		t.Errorf("dirwalker.Walk returned error: %v", err)
+		t.Errorf("dirwalker.Start returned error: %v", err)
 		t.FailNow()
 	}
 	dirwalker.Run()
@@ -191,9 +191,9 @@ func TestWalkDirectoryParallelIgnoresAbsoluteGitPath(t *testing.T) {
 	absGitDir := filepath.Join(absBaseDir, ".git")
 
 	dirwalker := NewDirectoryWalker(inputChan)
-	err := dirwalker.Walk(absBaseDir)
+	err := dirwalker.Start(absBaseDir)
 	if err != nil {
-		t.Errorf("dirwalker.Walk returned error: %v", err)
+		t.Errorf("dirwalker.Start returned error: %v", err)
 		t.FailNow()
 	}
 	dirwalker.Run()

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -393,7 +393,7 @@ func Process() {
 		directoryWalker := NewDirectoryWalker(fileListQueue)
 
 		for _, f := range DirFilePaths {
-			err := directoryWalker.Walk(f)
+			err := directoryWalker.Start(f)
 			if err != nil {
 				fmt.Printf("failed to walk %s: %v", f, err)
 				os.Exit(1)

--- a/vendor/github.com/dbaggerman/cuba/README.md
+++ b/vendor/github.com/dbaggerman/cuba/README.md
@@ -3,17 +3,75 @@ Project Cuba
 
 Experiment in allowing workers to own the means of production.
 
-Go's built in `chan`s are based on the Communicating Sequential Processes (CSP)
-model. They work well when the processing is sequential, i.e.
+Go makes many parallel cases easy to implement. Cuba aims to simplify some of
+the cases that aren't as easy to implement.
 
+If your algorithm can handle unbounded parallelism, then just spawn thousands
+of goroutines and let the Go runtime figure out how to make it work. However,
+this doesn't work if you have limits on external resources like open file
+descriptors or database connection handles. It also may not be the most memory
+efficient since each goroutine needs its own call stack.
+
+For bounded parallelism, Go's `chan`s allow splitting a task into a sequence of
+steps that happen in parallel. This model supports fanning in and out to
+increase the parallelism beyond the number of sequential steps.
+
+The limitation of using `chan`s is that they only work so long as the pipeline
+of work is unidirectional. Simple linear sequences are easiest, but you can
+construct any acyclical graph.
+
+Cuba aims to support parallelism where the dataflow may be cyclical.
+
+One example is a crawler style algorithm which involves both taking a node to
+process, and pushing newly discovered nodes back onto the queue.
+
+Another example is backing off and retrying without head-of-line blocking. Work
+items could be pushed to the back of the queue to be retried when they come
+around again.
+
+Usage
+=====
+
+First, define a worker function:
+
+```go
+func doWork(handle *cuba.Handle) {
+	item := handle.Item().(myItemType)
+
+  // Do something with item
+
+  for _, newItem := range newItemsFound {
+    handle.Push(newItem)
+    // Optionally: handle.Sync()
+  }
+}
 ```
-Producer -> Processor [-> Processor ...] -> Consumer
+
+Normally, `handle.Push()` buffers the new items before releasing them back to
+the work pool. When the function returns, the pool mutex will be aquired once
+and the items pushed as a batch. This means that other threads may sit idle
+until the function returns.
+
+Calling `handle.Sync()` will immediately aquire the lock and push any items in
+the buffer. This will increase lock contention, but may improve parallelism if
+you have long running workers.
+
+Then initialize a pool, seed with initial items, and wait for processing to complete.
+
+```go
+  // Initialize a new pool.
+  // Swap `cuba.NewQueue()` for `cuba.NewStack()` for LIFO order
+	pool := cuba.New(doWork, cuba.NewQueue())
+
+  // Optionally: pool.SetMaxWorkers(n)
+
+  // Seed the pool with initial work
+  // Workers are started as soon as something is available to process
+  pool.Push(myFirstItem)
+
+  // Wait for the workers to finish processing all work and terminate
+  pool.Finish()
 ```
 
-But not everything fits well with this model, like when work is discovered as
-part of the processing. Examples are walking a directory structure, and finding
-more subdirectories as you go -- or a web crawler following hyperlinks from the
-pages it crawls.
+By default, `cuba` pools have a maximum thread count equal to `runtime.NumCPU()`. This can be changed by calling `pool.SetMaxWorkers`.
 
-Cuba attempts to build a parallel system where processes can both consume and
-produce work simultaneously.


### PR DESCRIPTION
Relates to #134.

I found an issue in `cuba`, which allowed it to create more workers than it was supposed to. This meant that the `DirectoryWalker` could have more directory handles open than it was supposed to. Depending on the directory layout, it may have been significantly more.

This pulls in the a version (`v0.3.2`) with the fix.

While I was at it, I also refactored `DirectoryWalker` so that the handles get closed as soon as possible, rather than being kept open until after the entries have been processed.