### PR TITLE
Issue 137

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,9 @@ func main() {
 		Version: processor.Version,
 		Run: func(cmd *cobra.Command, args []string) {
 			processor.DirFilePaths = args
+			if processor.ConfigureLimits != nil {
+				processor.ConfigureLimits()
+			}
 			processor.ConfigureGc()
 			processor.ConfigureLazy(true)
 			processor.Process()

--- a/processor/file.go
+++ b/processor/file.go
@@ -230,6 +230,7 @@ func newFileJob(path, name string, fileInfo os.FileInfo) *FileJob {
 			Filename:          name,
 			Extension:         extension,
 			PossibleLanguages: language,
+			Bytes:             fileInfo.Size(),
 		}
 	} else if Verbose {
 		printWarn(fmt.Sprintf("skipping file unknown extension: %s", name))

--- a/processor/file.go
+++ b/processor/file.go
@@ -65,6 +65,7 @@ func NewDirectoryWalker(output chan<- *FileJob) *DirectoryWalker {
 	}
 
 	directoryWalker.buffer = cuba.New(directoryWalker.Walk, cuba.NewStack())
+	directoryWalker.buffer.SetMaxWorkers(int32(DirectoryWalkerJobWorkers))
 
 	return directoryWalker
 }

--- a/processor/file_test.go
+++ b/processor/file_test.go
@@ -216,14 +216,7 @@ func TestNewFileJobFullname(t *testing.T) {
 	ProcessConstants()
 	AllowListExtensions = []string{}
 
-	fi, err := os.Stat("../examples/issue114/makefile")
-	if err != nil {
-		dir, _ := os.Getwd()
-		t.Logf("os.Getwd: %s", dir)
-
-		t.Errorf("os.Stat ./examples/issue114/makefile: %v", err)
-		t.FailNow()
-	}
+	fi, _ := os.Stat("../examples/issue114/makefile")
 	job := newFileJob("../examples/issue114/", "makefile", fi)
 
 	if job.PossibleLanguages[0] != "Makefile" {

--- a/processor/file_test.go
+++ b/processor/file_test.go
@@ -216,8 +216,15 @@ func TestNewFileJobFullname(t *testing.T) {
 	ProcessConstants()
 	AllowListExtensions = []string{}
 
-	fi, _ := os.Stat("./examples/issue114/makefile")
-	job := newFileJob("./examples/issue114/", "makefile", fi)
+	fi, err := os.Stat("../examples/issue114/makefile")
+	if err != nil {
+		dir, _ := os.Getwd()
+		t.Logf("os.Getwd: %s", dir)
+
+		t.Errorf("os.Stat ./examples/issue114/makefile: %v", err)
+		t.FailNow()
+	}
+	job := newFileJob("../examples/issue114/", "makefile", fi)
 
 	if job.PossibleLanguages[0] != "Makefile" {
 		t.Error("Expected makefile got", job.PossibleLanguages[0])
@@ -227,8 +234,8 @@ func TestNewFileJobFullname(t *testing.T) {
 func TestNewFileJob(t *testing.T) {
 	ProcessConstants()
 
-	fi, _ := os.Stat("./examples/issue114/java")
-	job := newFileJob("./examples/issue114/", "java", fi)
+	fi, _ := os.Stat("../examples/issue114/java")
+	job := newFileJob("../examples/issue114/", "java", fi)
 
 	if job.PossibleLanguages[0] != "#!" {
 		t.Error("Expected special value #! got", job.PossibleLanguages[0])
@@ -239,8 +246,8 @@ func TestNewFileJobGitIgnore(t *testing.T) {
 	AllowListExtensions = []string{}
 	ProcessConstants()
 
-	fi, _ := os.Stat("./examples/issue114/.gitignore")
-	job := newFileJob("./examples/issue114/", ".gitignore", fi)
+	fi, _ := os.Stat("../examples/issue114/.gitignore")
+	job := newFileJob("../examples/issue114/", ".gitignore", fi)
 
 	if job.PossibleLanguages[0] != "gitignore" {
 		t.Error("Expected gitignore got", job.PossibleLanguages[0])
@@ -251,8 +258,8 @@ func TestNewFileJobIgnore(t *testing.T) {
 	AllowListExtensions = []string{}
 	ProcessConstants()
 
-	fi, _ := os.Stat("./examples/issue114/.ignore")
-	job := newFileJob("./examples/issue114/", ".ignore", fi)
+	fi, _ := os.Stat("../examples/issue114/.ignore")
+	job := newFileJob("../examples/issue114/", ".ignore", fi)
 
 	if job.PossibleLanguages[0] != "ignore" {
 		t.Error("Expected ignore got", job.PossibleLanguages[0])
@@ -262,8 +269,8 @@ func TestNewFileJobIgnore(t *testing.T) {
 func TestNewFileJobLicense(t *testing.T) {
 	ProcessConstants()
 
-	fi, _ := os.Stat("./examples/issue114/license")
-	job := newFileJob("./examples/issue114/", "license", fi)
+	fi, _ := os.Stat("../examples/issue114/license")
+	job := newFileJob("../examples/issue114/", "license", fi)
 
 	if job.PossibleLanguages[0] != "License" {
 		t.Error("Expected License got", job.PossibleLanguages[0])
@@ -273,8 +280,8 @@ func TestNewFileJobLicense(t *testing.T) {
 func TestNewFileJobYAML(t *testing.T) {
 	ProcessConstants()
 
-	fi, _ := os.Stat("./examples/issue114/.travis.yml")
-	job := newFileJob("./examples/issue114/", ".travis.yml", fi)
+	fi, _ := os.Stat("../examples/issue114/.travis.yml")
+	job := newFileJob("../examples/issue114/", ".travis.yml", fi)
 
 	if job.PossibleLanguages[0] != "YAML" {
 		t.Error("Expected YAML got", job.PossibleLanguages[0])

--- a/processor/filereader.go
+++ b/processor/filereader.go
@@ -1,0 +1,46 @@
+package processor
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"fmt"
+)
+
+type FileReader struct{
+	Buffer *bytes.Buffer
+}
+
+func NewFileReader() FileReader {
+	return FileReader{
+		Buffer: &bytes.Buffer{},
+	}
+}
+
+func (reader *FileReader) ReadFile(path string, size int) ([]byte, error) {
+	fd, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("error opening %s: %v", path, err)
+	}
+	defer fd.Close()
+
+	// Reset contents, but retain the underlying memory that's already been
+	// allocated
+	reader.Buffer.Reset()
+
+	// stat, err := fd.Stat()
+	// if err != nil {
+	// 	return nil, fmt.Errorf("error opening %s: %v", path, err)
+	// }
+
+	//reader.Buffer.Grow(int(stat.Size()))
+	reader.Buffer.Grow(size)
+
+	_, err = io.Copy(reader.Buffer, fd)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %v", path, err)
+	}
+
+	return reader.Buffer.Bytes(), nil
+}
+

--- a/processor/filereader.go
+++ b/processor/filereader.go
@@ -2,12 +2,12 @@ package processor
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
-	"fmt"
 )
 
-type FileReader struct{
+type FileReader struct {
 	Buffer *bytes.Buffer
 }
 
@@ -43,4 +43,3 @@ func (reader *FileReader) ReadFile(path string, size int) ([]byte, error) {
 
 	return reader.Buffer.Bytes(), nil
 }
-

--- a/processor/filereader.go
+++ b/processor/filereader.go
@@ -28,7 +28,7 @@ func (reader *FileReader) ReadFile(path string, size int) ([]byte, error) {
 	// file we would allocate an equally huge buffer. Rather than keep the huge
 	// buffer around forever, it's probably worth eating the GC cost of
 	// replacing it so that we can release the memory.
-	if reader.Buffer.Cap() > LargeByteCount {
+	if int64(reader.Buffer.Cap()) > LargeByteCount {
 		reader.Buffer = &bytes.Buffer{}
 	}
 

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -675,21 +675,42 @@ func getFormattedTime() string {
 // Prints a message to stdout if flag to enable warning output is set
 func printWarn(msg string) {
 	if Verbose {
-		fmt.Println(fmt.Sprintf(" WARN %s: %s", getFormattedTime(), msg))
+		fmt.Printf(" WARN %s: %s\n", getFormattedTime(), msg)
+	}
+}
+
+// Prints a message to stdout if flag to enable warning output is set
+func printWarnf(msg string, args ...interface{}) {
+	if Verbose {
+		printWarn(fmt.Sprintf(msg, args...))
 	}
 }
 
 // Prints a message to stdout if flag to enable debug output is set
 func printDebug(msg string) {
 	if Debug {
-		fmt.Println(fmt.Sprintf("DEBUG %s: %s", getFormattedTime(), msg))
+		fmt.Printf("DEBUG %s: %s\n", getFormattedTime(), msg)
+	}
+}
+
+// Prints a message to stdout if flag to enable debug output is set
+func printDebugf(msg string, args ...interface{}) {
+	if Debug {
+		printDebug(fmt.Sprintf(msg, args...))
 	}
 }
 
 // Prints a message to stdout if flag to enable trace output is set
 func printTrace(msg string) {
 	if Trace {
-		fmt.Println(fmt.Sprintf("TRACE %s: %s", getFormattedTime(), msg))
+		fmt.Printf("TRACE %s: %s\n", getFormattedTime(), msg)
+	}
+}
+
+// Prints a message to stdout if flag to enable trace output is set
+func printTracef(msg string, args ...interface{}) {
+	if Trace {
+		printTrace(fmt.Sprintf(msg, args...))
 	}
 }
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -386,7 +386,6 @@ func Process() {
 	}
 
 	fileListQueue := make(chan *FileJob, FileListQueueSize)                     // Files ready to be read from disk
-	fileReadContentJobQueue := make(chan *FileJob, FileReadContentJobQueueSize) // Files ready to be processed
 	fileSummaryJobQueue := make(chan *FileJob, FileSummaryJobQueueSize)         // Files ready to be summarised
 
 	go func() {
@@ -402,8 +401,7 @@ func Process() {
 
 		directoryWalker.Run()
 	}()
-	go fileReaderWorker(fileListQueue, fileReadContentJobQueue)
-	go fileProcessorWorker(fileReadContentJobQueue, fileSummaryJobQueue)
+	go fileProcessorWorker(fileListQueue, fileSummaryJobQueue)
 
 	result := fileSummarize(fileSummaryJobQueue)
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -385,8 +385,8 @@ func Process() {
 		printDebug(fmt.Sprintf("PathDenyList: %v", PathDenyList))
 	}
 
-	fileListQueue := make(chan *FileJob, FileListQueueSize)                     // Files ready to be read from disk
-	fileSummaryJobQueue := make(chan *FileJob, FileSummaryJobQueueSize)         // Files ready to be summarised
+	fileListQueue := make(chan *FileJob, FileListQueueSize)             // Files ready to be read from disk
+	fileSummaryJobQueue := make(chan *FileJob, FileSummaryJobQueueSize) // Files ready to be summarised
 
 	go func() {
 		directoryWalker := NewDirectoryWalker(fileListQueue)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -142,6 +142,8 @@ var LanguageFeaturesMutex = sync.Mutex{}
 // Start time in milli seconds in case we want the total time
 var startTimeMilli = makeTimestampMilli()
 
+var ConfigureLimits func() = nil
+
 // ConfigureGc needs to be set outside of ProcessConstants because it should only be enabled in command line
 // mode https://github.com/boyter/scc/issues/32
 func ConfigureGc() {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -82,11 +82,11 @@ var FileOutput = ""
 // PathDenyList sets the paths that should be skipped
 var PathDenyList = []string{}
 
+// DirectoryWalkerJobWorkers is the number of workers which will walk the directory tree
+var DirectoryWalkerJobWorkers = runtime.NumCPU()
+
 // FileListQueueSize is the queue of files found and ready to be read into memory
 var FileListQueueSize = runtime.NumCPU()
-
-// FileReadJobWorkers is the number of processes that read files off disk into memory
-var FileReadJobWorkers = runtime.NumCPU() * 4
 
 // FileReadContentJobQueueSize is a queue of files ready to be processed
 var FileReadContentJobQueueSize = runtime.NumCPU()

--- a/processor/processor_unix.go
+++ b/processor/processor_unix.go
@@ -43,12 +43,14 @@ func ConfigureLimitsUnix() {
 			scaleWorkersToLimit(int(limit.Max), margin)
 		}
 
-		err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit)
-		if err != nil {
-			printWarnf("Adjusting file limit failed: %v", err)
-			scaleWorkersToLimit(int(originalLimit), margin)
-		} else {
-			printDebugf("Adjusted open file limit to %d", limit.Cur)
+		if originalLimit < limit.Max {
+			err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit)
+			if err != nil {
+				printWarnf("Adjusting file limit failed: %v", err)
+				scaleWorkersToLimit(int(originalLimit), margin)
+			} else {
+				printDebugf("Adjusted open file limit to %d", limit.Cur)
+			}
 		}
 	}
 }

--- a/processor/processor_unix.go
+++ b/processor/processor_unix.go
@@ -1,0 +1,61 @@
+package processor
+
+import (
+	"syscall"
+)
+
+func init() {
+	// Doing the limits configuration in init() directly is possible, but it
+	// means that we wouldn't have access to user flags like Verbose.
+	ConfigureLimits = ConfigureLimitsUnix
+}
+
+func ConfigureLimitsUnix() {
+	margin := 16
+
+	// High water mark of how many open files we may need.
+	// Each FileReadJobWorker needs one + DirectoryWorker may need up to one per runtime CPU
+	// We pad it out a bit because every process needs a few handles just to exist
+	highWaterMark := uint64(FileProcessJobWorkers + DirectoryWalkerJobWorkers + margin)
+
+	limit := syscall.Rlimit{}
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit)
+	if err != nil {
+		printWarnf("Unable to determine open file limit: %v", err)
+		return
+	}
+
+	originalLimit := limit.Cur
+
+	printDebugf("Open file limit: current=%d max=%d", limit.Cur, limit.Max)
+
+	// limit.Cur is the current (soft) limit. If this is too low, we may be
+	// able to raise it with Setrlimit
+	if limit.Cur < highWaterMark {
+		limit.Cur = highWaterMark
+
+		// limit.Max is the hard limit. If this is still too low, we'll scale
+		// it as high as we can but we also have to scale back how many workers
+		// we launch.
+		if limit.Max < highWaterMark {
+			printWarn("Scaling down workers to fit open file ulimit - performance may be sub-optimal")
+			limit.Cur = limit.Max
+			scaleWorkersToLimit(int(limit.Max), margin)
+		}
+
+		err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit)
+		if err != nil {
+			printWarnf("Adjusting file limit failed: %v", err)
+			scaleWorkersToLimit(int(originalLimit), margin)
+		} else {
+			printDebugf("Adjusted open file limit to %d", limit.Cur)
+		}
+	}
+}
+
+func scaleWorkersToLimit(max, margin int) {
+	scalingBase := (max - margin) / 5
+
+	DirectoryWalkerJobWorkers = scalingBase
+	FileProcessJobWorkers = scalingBase * 4
+}

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"hash"
-	"io/ioutil"
 	"sync"
 	"sync/atomic"
 
@@ -53,6 +52,10 @@ var ByteOrderMarks = [][]byte{
 	{14, 254, 255},        // SCSU
 	{251, 238, 40},        // BOCU-1
 	{132, 49, 149, 51},    // GB-18030
+}
+
+var duplicates = CheckDuplicates{
+	hashes: make(map[int64][][]byte),
 }
 
 func checkForMatchSingle(currentByte byte, index int, endPoint int, matches []byte, fileJob *FileJob) bool {
@@ -373,7 +376,6 @@ func verifyIgnoreEscape(langFeatures LanguageFeature, fileJob *FileJob, index in
 func CountStats(fileJob *FileJob) {
 
 	// If the file has a length of 0 it is is empty then we say it has no lines
-	fileJob.Bytes = int64(len(fileJob.Content))
 	if fileJob.Bytes == 0 {
 		fileJob.Lines = 0
 		return
@@ -546,9 +548,6 @@ func CountStats(fileJob *FileJob) {
 		avgLineByteCount := len(fileJob.Content) / int(fileJob.Lines)
 		minifiedGeneratedCheck(avgLineByteCount, fileJob)
 	}
-
-	// Save memory by unsetting the content as we no longer require it
-	fileJob.Content = nil
 }
 
 func minifiedGeneratedCheck(avgLineByteCount int, fileJob *FileJob) {
@@ -589,30 +588,36 @@ func checkBomSkip(fileJob *FileJob) int {
 	return 0
 }
 
-// Reads entire file into memory and then pushes it onto the next queue
-func fileReaderWorker(input chan *FileJob, output chan *FileJob) {
+// Reads and processes files from input chan in parallel, and sends results to
+// output chan
+func fileProcessorWorker(input chan *FileJob, output chan *FileJob) {
 	var startTime int64
 	var wg sync.WaitGroup
 
-	for i := 0; i < FileReadJobWorkers; i++ {
+	for i := 0; i < FileProcessJobWorkers; i++ {
 		wg.Add(1)
 		go func() {
-			for res := range input {
+			reader := NewFileReader()
+
+			for job := range input {
 				atomic.CompareAndSwapInt64(&startTime, 0, makeTimestampMilli())
 
 				fileStartTime := makeTimestampNano()
-				content, err := ioutil.ReadFile(res.Location)
+
+				content, err := reader.ReadFile(job.Location, int(job.Bytes))
 
 				if Trace {
-					printTrace(fmt.Sprintf("nanoseconds read into memory: %s: %d", res.Location, makeTimestampNano()-fileStartTime))
+					printTrace(fmt.Sprintf("nanoseconds read into memory: %s: %d", job.Location, makeTimestampNano()-fileStartTime))
 				}
 
 				if err == nil {
-					res.Content = content
-					output <- res
+					job.Content = content
+					if processFile(job) {
+						output <- job
+					}
 				} else {
 					if Verbose {
-						printWarn(fmt.Sprintf("error reading: %s %s", res.Location, err))
+						printWarn(fmt.Sprintf("error reading: %s %s", job.Location, err))
 					}
 				}
 			}
@@ -629,106 +634,84 @@ func fileReaderWorker(input chan *FileJob, output chan *FileJob) {
 			printDebug(fmt.Sprintf("milliseconds reading files into memory: %d", makeTimestampMilli()-startTime))
 		}
 	}()
+
 }
 
-var duplicates = CheckDuplicates{
-	hashes: make(map[int64][][]byte),
-}
+// Process a single file
+// File must have been read to job.Content already
+func processFile(job *FileJob) bool {
+	fileStartTime := makeTimestampNano()
 
-// Does the actual processing of stats and as such contains the hot path CPU call
-func fileProcessorWorker(input chan *FileJob, output chan *FileJob) {
-	var startTime int64
-	var wg sync.WaitGroup
-	for i := 0; i < FileProcessJobWorkers; i++ {
-		wg.Add(1)
-		go func() {
-			for res := range input {
-				atomic.CompareAndSwapInt64(&startTime, 0, makeTimestampMilli())
+	contents := job.Content
 
-				fileStartTime := makeTimestampNano()
+	// Needs to always run to ensure the language is set
+	job.Language = DetermineLanguage(job.Filename, job.Language, job.PossibleLanguages, job.Content)
 
-				// Needs to always run to ensure the language is set
-				res.Language = DetermineLanguage(res.Filename, res.Language, res.PossibleLanguages, res.Content)
+	// If the type is #! we should check to see if we can identify
+	if job.Language == SheBang {
+		cutoff := 200
 
-				// If the type is #! we should check to see if we can identify
-				if res.Language == SheBang {
-					cutoff := 200
+		// To avoid runtime panic check if the content we are cutting is smaller than 200
+		if len(contents) < cutoff {
+			cutoff = len(contents)
+		}
 
-					// To avoid runtime panic check if the content we are cutting is smaller than 200
-					if len(res.Content) < cutoff {
-						cutoff = len(res.Content)
-					}
-
-					l, err := DetectSheBang(string(res.Content[:cutoff]))
-					if err == nil {
-						if Verbose {
-							printWarn(fmt.Sprintf("detected #! %s for %s", l, res.Location))
-						}
-
-						res.Language = l
-						LoadLanguageFeature(l)
-					} else {
-						if Verbose {
-							printWarn(fmt.Sprintf("unable to determine #! language for %s", res.Location))
-						}
-						continue
-					}
-				}
-
-				CountStats(res)
-
-				if Duplicates {
-					duplicates.mux.Lock()
-					if duplicates.Check(res.Bytes, res.Hash) {
-						if Verbose {
-							printWarn(fmt.Sprintf("skipping duplicate file: %s", res.Location))
-						}
-
-						duplicates.mux.Unlock()
-						continue
-					}
-
-					duplicates.Add(res.Bytes, res.Hash)
-					duplicates.mux.Unlock()
-				}
-
-				if IgnoreMinifiedGenerate && res.Minified {
-					if Verbose {
-						printWarn(fmt.Sprintf("skipping minified/generated file: %s", res.Location))
-					}
-					continue
-				}
-
-				if NoLarge && res.Lines >= LargeLineCount {
-					if Verbose {
-						printWarn(fmt.Sprintf("skipping large file due to line length: %s", res.Location))
-					}
-					continue
-				}
-
-				if Trace {
-					printTrace(fmt.Sprintf("nanoseconds process: %s: %d", res.Location, makeTimestampNano()-fileStartTime))
-				}
-
-				if !res.Binary {
-					output <- res
-				} else {
-					if Verbose {
-						printWarn(fmt.Sprintf("skipping file identified as binary: %s", res.Location))
-					}
-				}
+		lang, err := DetectSheBang(string(contents[:cutoff]))
+		if err != nil {
+			if Verbose {
+				printWarn(fmt.Sprintf("unable to determine #! language for %s", job.Location))
 			}
+			return false
+		}
+		if Verbose {
+			printWarn(fmt.Sprintf("detected #! %s for %s", lang, job.Location))
+		}
 
-			wg.Done()
-		}()
+		job.Language = lang
+		LoadLanguageFeature(lang)
 	}
 
-	go func() {
-		wg.Wait()
-		close(output)
-	}()
+	CountStats(job)
 
-	if Debug {
-		printDebug(fmt.Sprintf("milliseconds processing files: %d", makeTimestampMilli()-startTime))
+	if Duplicates {
+		duplicates.mux.Lock()
+		if duplicates.Check(job.Bytes, job.Hash) {
+			if Verbose {
+				printWarn(fmt.Sprintf("skipping duplicate file: %s", job.Location))
+			}
+
+			duplicates.mux.Unlock()
+			return false
+		}
+
+		duplicates.Add(job.Bytes, job.Hash)
+		duplicates.mux.Unlock()
+	}
+
+	if IgnoreMinifiedGenerate && job.Minified {
+		if Verbose {
+			printWarn(fmt.Sprintf("skipping minified/generated file: %s", job.Location))
+		}
+		return false
+	}
+
+	if NoLarge && job.Lines >= LargeLineCount {
+		if Verbose {
+			printWarn(fmt.Sprintf("skipping large file due to line length: %s", job.Location))
+		}
+		return false
+	}
+
+	if Trace {
+		printTrace(fmt.Sprintf("nanoseconds process: %s: %d", job.Location, makeTimestampNano()-fileStartTime))
+	}
+
+	if !job.Binary {
+		return true
+	} else {
+		if Verbose {
+			printWarn(fmt.Sprintf("skipping file identified as binary: %s", job.Location))
+		}
+		return false
 	}
 }

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -374,7 +374,6 @@ func verifyIgnoreEscape(langFeatures LanguageFeature, fileJob *FileJob, index in
 // Newlines belong to the line they started on so a file of \n means only 1 line
 // This is the 'hot' path for the application and needs to be as fast as possible
 func CountStats(fileJob *FileJob) {
-
 	// If the file has a length of 0 it is is empty then we say it has no lines
 	if fileJob.Bytes == 0 {
 		fileJob.Lines = 0

--- a/processor/workers_regression_test.go
+++ b/processor/workers_regression_test.go
@@ -10,7 +10,7 @@ func TestCountStatsIssue72(t *testing.T) {
 		Language: "C#",
 	}
 
-	fileJob.Content = []byte(`   // Comment 1
+	fileJob.SetContent(`   // Comment 1
 namespace Baz
 {
     using System;
@@ -55,7 +55,7 @@ func TestCountStatsPr76(t *testing.T) {
 		Language: "Go",
 	}
 
-	fileJob.Content = []byte(`package main
+	fileJob.SetContent(`package main
 var MyString = ` + "`\\`" + `
 // Comment`)
 
@@ -85,7 +85,7 @@ func TestCountStatsIssue62(t *testing.T) {
 		Language: "Python",
 	}
 
-	fileJob.Content = []byte(`def f():
+	fileJob.SetContent(`def f():
 	"""
 	This is a docstring
 	"""
@@ -126,7 +126,7 @@ func TestCountStatsIssue123(t *testing.T) {
 		Language: "Python",
 	}
 
-	fileJob.Content = []byte(`"""
+	fileJob.SetContent(`"""
 hello there! how's it going?
 """`)
 

--- a/processor/workers_test.go
+++ b/processor/workers_test.go
@@ -7,6 +7,11 @@ import (
 	"testing"
 )
 
+func (job *FileJob) SetContent(content string) {
+	job.Content = []byte(content)
+	job.Bytes = int64(len(job.Content))
+}
+
 func TestIsWhitespace(t *testing.T) {
 	if !isWhitespace(' ') {
 		t.Errorf("Expected to be true")
@@ -49,14 +54,14 @@ func TestCountStatsLines(t *testing.T) {
 	// Interestingly this file would be 0 lines in "wc -l" because it only counts newlines
 	// all others count this as 1
 	fileJob.Lines = 0
-	fileJob.Content = []byte("a")
+	fileJob.SetContent("a")
 	CountStats(&fileJob)
 	if fileJob.Lines != 1 {
 		t.Errorf("One line expected got %d", fileJob.Lines)
 	}
 
 	fileJob.Lines = 0
-	fileJob.Content = []byte("a\n")
+	fileJob.SetContent("a\n")
 	CountStats(&fileJob)
 	if fileJob.Lines != 1 {
 		t.Errorf("One line expected got %d", fileJob.Lines)
@@ -65,21 +70,21 @@ func TestCountStatsLines(t *testing.T) {
 	// tokei counts this as 1 because its still on a single line unless something follows
 	// the newline its still 1 line
 	fileJob.Lines = 0
-	fileJob.Content = []byte("1\n")
+	fileJob.SetContent("1\n")
 	CountStats(&fileJob)
 	if fileJob.Lines != 1 {
 		t.Errorf("One line expected got %d", fileJob.Lines)
 	}
 
 	fileJob.Lines = 0
-	fileJob.Content = []byte("1\n2\n")
+	fileJob.SetContent("1\n2\n")
 	CountStats(&fileJob)
 	if fileJob.Lines != 2 {
 		t.Errorf("Two lines expected got %d", fileJob.Lines)
 	}
 
 	fileJob.Lines = 0
-	fileJob.Content = []byte("1\n2\n3")
+	fileJob.SetContent("1\n2\n3")
 	CountStats(&fileJob)
 	if fileJob.Lines != 3 {
 		t.Errorf("Three lines expected got %d", fileJob.Lines)
@@ -89,7 +94,7 @@ func TestCountStatsLines(t *testing.T) {
 	for i := 0; i < 5000; i++ {
 		content += "a\n"
 		fileJob.Lines = 0
-		fileJob.Content = []byte(content)
+		fileJob.SetContent(content)
 		CountStats(&fileJob)
 		if fileJob.Lines != int64(i+1) {
 			t.Errorf("Expected %d got %d", i+1, fileJob.Lines)
@@ -113,28 +118,28 @@ func TestCountStatsCode(t *testing.T) {
 	// Interestingly this file would be 0 lines in "wc -l" because it only counts newlines
 	// all others count this as 1
 	fileJob.Code = 0
-	fileJob.Content = []byte("a")
+	fileJob.SetContent("a")
 	CountStats(&fileJob)
 	if fileJob.Code != 1 {
 		t.Errorf("One line expected got %d", fileJob.Code)
 	}
 
 	fileJob.Code = 0
-	fileJob.Content = []byte("i++ # comment")
+	fileJob.SetContent("i++ # comment")
 	CountStats(&fileJob)
 	if fileJob.Code != 1 {
 		t.Errorf("One line expected got %d", fileJob.Code)
 	}
 
 	fileJob.Code = 0
-	fileJob.Content = []byte("i++ // comment")
+	fileJob.SetContent("i++ // comment")
 	CountStats(&fileJob)
 	if fileJob.Code != 1 {
 		t.Errorf("One line expected got %d", fileJob.Code)
 	}
 
 	fileJob.Code = 0
-	fileJob.Content = []byte("a\n")
+	fileJob.SetContent("a\n")
 	CountStats(&fileJob)
 	if fileJob.Code != 1 {
 		t.Errorf("One line expected got %d", fileJob.Code)
@@ -143,21 +148,21 @@ func TestCountStatsCode(t *testing.T) {
 	// tokei counts this as 1 because its still on a single line unless something follows
 	// the newline its still 1 line
 	fileJob.Code = 0
-	fileJob.Content = []byte("1\n")
+	fileJob.SetContent("1\n")
 	CountStats(&fileJob)
 	if fileJob.Code != 1 {
 		t.Errorf("One line expected got %d", fileJob.Code)
 	}
 
 	fileJob.Code = 0
-	fileJob.Content = []byte("1\n2\n")
+	fileJob.SetContent("1\n2\n")
 	CountStats(&fileJob)
 	if fileJob.Code != 2 {
 		t.Errorf("Two lines expected got %d", fileJob.Code)
 	}
 
 	fileJob.Code = 0
-	fileJob.Content = []byte("1\n2\n3")
+	fileJob.SetContent("1\n2\n3")
 	CountStats(&fileJob)
 	if fileJob.Code != 3 {
 		t.Errorf("Three lines expected got %d", fileJob.Code)
@@ -167,7 +172,7 @@ func TestCountStatsCode(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		content += "a\n"
 		fileJob.Code = 0
-		fileJob.Content = []byte(content)
+		fileJob.SetContent(content)
 		CountStats(&fileJob)
 		if fileJob.Code != int64(i+1) {
 			t.Errorf("Expected %d got %d", i+1, fileJob.Code)
@@ -181,7 +186,7 @@ func TestCountStatsWithQuotes(t *testing.T) {
 	fileJob.Code = 0
 	fileJob.Comment = 0
 	fileJob.Complexity = 0
-	fileJob.Content = []byte(`var test = "/*";`)
+	fileJob.SetContent(`var test = "/*";`)
 	CountStats(&fileJob)
 	if fileJob.Code != 1 {
 		t.Errorf("One line expected got %d", fileJob.Code)
@@ -193,7 +198,7 @@ func TestCountStatsWithQuotes(t *testing.T) {
 	fileJob.Code = 0
 	fileJob.Comment = 0
 	fileJob.Complexity = 0
-	fileJob.Content = []byte(`t = " if ";`)
+	fileJob.SetContent(`t = " if ";`)
 	CountStats(&fileJob)
 	if fileJob.Code != 1 {
 		t.Errorf("One line expected got %d", fileJob.Code)
@@ -208,7 +213,7 @@ func TestCountStatsWithQuotes(t *testing.T) {
 	fileJob.Code = 0
 	fileJob.Comment = 0
 	fileJob.Complexity = 0
-	fileJob.Content = []byte(`t = " if switch for while do loop != == && || ";`)
+	fileJob.SetContent(`t = " if switch for while do loop != == && || ";`)
 	CountStats(&fileJob)
 	if fileJob.Code != 1 {
 		t.Errorf("One line expected got %d", fileJob.Code)
@@ -233,49 +238,49 @@ func TestCountStatsBlankLines(t *testing.T) {
 	}
 
 	fileJob.Blank = 0
-	fileJob.Content = []byte(" ")
+	fileJob.SetContent(" ")
 	CountStats(&fileJob)
 	if fileJob.Blank != 1 {
 		t.Errorf("One line expected got %d", fileJob.Blank)
 	}
 
 	fileJob.Blank = 0
-	fileJob.Content = []byte("\n")
+	fileJob.SetContent("\n")
 	CountStats(&fileJob)
 	if fileJob.Blank != 1 {
 		t.Errorf("One line expected got %d", fileJob.Blank)
 	}
 
 	fileJob.Blank = 0
-	fileJob.Content = []byte("\n ")
+	fileJob.SetContent("\n ")
 	CountStats(&fileJob)
 	if fileJob.Blank != 2 {
 		t.Errorf("Two line expected got %d", fileJob.Blank)
 	}
 
 	fileJob.Blank = 0
-	fileJob.Content = []byte("            ")
+	fileJob.SetContent("            ")
 	CountStats(&fileJob)
 	if fileJob.Blank != 1 {
 		t.Errorf("One line expected got %d", fileJob.Blank)
 	}
 
 	fileJob.Blank = 0
-	fileJob.Content = []byte("            \n             ")
+	fileJob.SetContent("            \n             ")
 	CountStats(&fileJob)
 	if fileJob.Blank != 2 {
 		t.Errorf("Two lines expected got %d", fileJob.Blank)
 	}
 
 	fileJob.Blank = 0
-	fileJob.Content = []byte("\r\n\r\n")
+	fileJob.SetContent("\r\n\r\n")
 	CountStats(&fileJob)
 	if fileJob.Blank != 2 {
 		t.Errorf("Two lines expected got %d", fileJob.Blank)
 	}
 
 	fileJob.Blank = 0
-	fileJob.Content = []byte("\r\n")
+	fileJob.SetContent("\r\n")
 	CountStats(&fileJob)
 	if fileJob.Blank != 1 {
 		t.Errorf("One line expected got %d", fileJob.Blank)
@@ -298,7 +303,7 @@ func TestCountStatsComplexityCount(t *testing.T) {
 
 	for _, check := range checks {
 		fileJob.Complexity = 0
-		fileJob.Content = []byte(check)
+		fileJob.SetContent(check)
 		fileJob.Language = "Java"
 		CountStats(&fileJob)
 		if fileJob.Complexity != 1 {
@@ -319,7 +324,7 @@ func TestCountStatsComplexityCountFalse(t *testing.T) {
 
 	for _, check := range checks {
 		fileJob.Complexity = 0
-		fileJob.Content = []byte(check)
+		fileJob.SetContent(check)
 		fileJob.Language = "Java"
 		CountStats(&fileJob)
 		if fileJob.Complexity != 0 {
@@ -354,7 +359,7 @@ func TestCountStatsCallback(t *testing.T) {
 	ProcessConstants()
 	fileJob := FileJob{}
 
-	fileJob.Content = []byte(`package foo
+	fileJob.SetContent(`package foo
 
 import com.foo.bar;
 
@@ -383,7 +388,7 @@ func TestCountStatsCallbackInterrupt(t *testing.T) {
 	ProcessConstants()
 	fileJob := FileJob{}
 
-	fileJob.Content = []byte(`package foo
+	fileJob.SetContent(`package foo
 
 import com.foo.bar;
 
@@ -408,7 +413,7 @@ func TestCountStatsEdgeCase1(t *testing.T) {
 		Language: "Java",
 	}
 
-	fileJob.Content = []byte(`/**/
+	fileJob.SetContent(`/**/
 `)
 
 	CountStats(&fileJob)
@@ -430,7 +435,7 @@ func TestCountStatsNestedComments(t *testing.T) {
 		Language: "Rust",
 	}
 
-	fileJob.Content = []byte(`/*/**/*/`)
+	fileJob.SetContent(`/*/**/*/`)
 
 	CountStats(&fileJob)
 
@@ -458,7 +463,7 @@ func TestCountStatsNestedCommentsJava(t *testing.T) {
 		Language: "Java",
 	}
 
-	fileJob.Content = []byte(`/*/**/*/`)
+	fileJob.SetContent(`/*/**/*/`)
 
 	CountStats(&fileJob)
 
@@ -485,7 +490,7 @@ func TestCountStatsNestedCommentsRegression(t *testing.T) {
 		Language: "Rust",
 	}
 
-	fileJob.Content = []byte(`t/*/**/*/`)
+	fileJob.SetContent(`t/*/**/*/`)
 
 	CountStats(&fileJob)
 
@@ -512,7 +517,7 @@ func TestCountStatsSingleCommentRegression(t *testing.T) {
 		Language: "Rust",
 	}
 
-	fileJob.Content = []byte(`t = "
+	fileJob.SetContent(`t = "
 /*
 ";`)
 
@@ -541,7 +546,7 @@ func TestCountStatsStringCheck(t *testing.T) {
 		Language: "Rust",
 	}
 
-	fileJob.Content = []byte(`let does_not_start = // "
+	fileJob.SetContent(`let does_not_start = // "
 "until here,
 test/*
 test"; // a quote: "`)
@@ -571,7 +576,7 @@ func TestCountStatsBosque(t *testing.T) {
 		Language: "Bosque",
 	}
 
-	fileJob.Content = []byte(`//This is a bosque test
+	fileJob.SetContent(`//This is a bosque test
 method offsetMomentum(px: Float, py: Float, pz: Float): Body {
       return this<~(vx=Float::div(px->negate(), Body::solar_mass), vy=Float::div(py->negate(), Body::solar_mass), vz=Float::div(pz->negate(), Body::solar_mass));
 }`)
@@ -711,7 +716,7 @@ func TestCountStatsRubyRegression(t *testing.T) {
 		Language: "Ruby",
 	}
 
-	fileJob.Content = []byte(`=begin
+	fileJob.SetContent(`=begin
 =end
 t`)
 
@@ -767,7 +772,7 @@ func TestEdgeCase(t *testing.T) {
 	// For C# we can enter a string using @" or " but if we do the former,
 	// and we don't skip over the full length we exit the string in this case
 	// which means we pick up the /* and the count is incorrect
-	fileJob.Content = []byte(`@"\ /*"
+	fileJob.SetContent(`@"\ /*"
 a`)
 
 	CountStats(&fileJob)
@@ -794,7 +799,7 @@ func TestEdgeCaseOther(t *testing.T) {
 	// For C# we can enter a string using @" or " but if we do the former,
 	// and we don't skip over the full length we exit the string in this case
 	// which means we pick up the /* and the count is incorrect
-	fileJob.Content = []byte(`@"C:\" /*
+	fileJob.SetContent(`@"C:\" /*
 a */`)
 
 	CountStats(&fileJob)
@@ -818,7 +823,7 @@ func TestCountStatsCSharpIgnoreEscape(t *testing.T) {
 		Language: "C#",
 	}
 
-	fileJob.Content = []byte(`namespace Ns
+	fileJob.SetContent(`namespace Ns
 {
    public class Cls
    {
@@ -891,10 +896,11 @@ func TestCountStatsIssue73(t *testing.T) {
 		Language: "Java",
 	}
 
-	fileJob.Content = []byte(`'\"'{
+	fileJob.SetContent(`'\"'{
 code
 
 `)
+	fileJob.Bytes = int64(len(fileJob.Content))
 
 	CountStats(&fileJob)
 
@@ -921,7 +927,7 @@ func TestCountStatsIssue106(t *testing.T) {
 		Language: "Go",
 	}
 
-	fileJob.Content = []byte("foo = `\nabc\"\ndef\n`")
+	fileJob.SetContent("foo = `\nabc\"\ndef\n`")
 
 	CountStats(&fileJob)
 }
@@ -931,7 +937,7 @@ func TestMinifiedGeneratedCheck(t *testing.T) {
 		Language: "Go",
 	}
 
-	fileJob.Content = []byte("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890ABCDEF")
+	fileJob.SetContent("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890ABCDEF")
 	MinifiedGenerated = true
 	CountStats(&fileJob)
 	MinifiedGenerated = false
@@ -946,7 +952,7 @@ func TestMinifiedGeneratedCheckTwoLines(t *testing.T) {
 		Language: "Go",
 	}
 
-	fileJob.Content = []byte("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890ABCDEF\n1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890ABCDEF")
+	fileJob.SetContent("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890ABCDEF\n1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890ABCDEF")
 	MinifiedGenerated = true
 	CountStats(&fileJob)
 	MinifiedGenerated = false
@@ -961,7 +967,7 @@ func TestMinifiedGeneratedCheckEdge(t *testing.T) {
 		Language: "Go",
 	}
 
-	fileJob.Content = []byte("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890ABCD")
+	fileJob.SetContent("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890ABCD")
 	MinifiedGenerated = true
 	CountStats(&fileJob)
 	MinifiedGenerated = false

--- a/processor/workers_tokei_test.go
+++ b/processor/workers_tokei_test.go
@@ -10,7 +10,7 @@ func TestCountStatsJava(t *testing.T) {
 		Language: "Java",
 	}
 
-	fileJob.Content = []byte(`/* 23 lines 16 code 4 comments 3 blanks */
+	fileJob.SetContent(`/* 23 lines 16 code 4 comments 3 blanks */
 
 /*
 * Simple test class
@@ -59,7 +59,7 @@ func TestCountStatsAccuracyCPlusPlus(t *testing.T) {
 		Language: "C++",
 	}
 
-	fileJob.Content = []byte(`/* 15 lines 7 code 4 comments 4 blanks */
+	fileJob.SetContent(`/* 15 lines 7 code 4 comments 4 blanks */
 
 #include <iostream>
 
@@ -101,7 +101,7 @@ func TestCountStatsAccuracyRakefile(t *testing.T) {
 		Language: "Rakefile",
 	}
 
-	fileJob.Content = []byte(`# 10 lines 4 code 2 comments 4 blanks
+	fileJob.SetContent(`# 10 lines 4 code 2 comments 4 blanks
 
 # this is a rakefile
 
@@ -138,7 +138,7 @@ func TestCountStatsAccuracyRuby(t *testing.T) {
 		Language: "Ruby",
 	}
 
-	fileJob.Content = []byte(`# 20 lines 9 code 8 comments 3 blanks
+	fileJob.SetContent(`# 20 lines 9 code 8 comments 3 blanks
 x = 3
 if x < 2
   p = "Smaller"
@@ -185,7 +185,7 @@ func TestCountStatsAccuracyTokeiTest(t *testing.T) {
 		Language: "Rust",
 	}
 
-	fileJob.Content = []byte(`// 39 lines 32 code 2 comments 5 blanks
+	fileJob.SetContent(`// 39 lines 32 code 2 comments 5 blanks
 
 /* /**/ */
 fn main() {


### PR DESCRIPTION
Refactors file reading and implements handling of `ulimit` on Unix-like operating systems.

For `ulimit` handling, it queries the current limits and raises the current (soft) limit if the hard limit allows it. If the hard limit is still too low then it will raise the current limit as high as it's allowed to and scale down the number of workers to fit.

Google is giving me mixed answers about what the default hard open file limit is, with everything from 512 to `unlimited`. I don't have a Mac to test with, but my Linux system has a soft limit of 2014 and a hard limit of 524288, so this will work fine for me until I can buy a CPU with 100,000 cores.

Testing this is awkward, but I ran `ulimit -n 50` in a shell and ran `scc` with `--verbose` to check the warning about scaling the limit. The hard limit was also set with `ulimit -Hn 50` to again see the warning message. In both cases I could also observe that `scc` didn't throw `too many open files` errors. I've got 8 cores / 16 threads, so I would normally expect to open up to 80 files at a time.

-----

I ended up folding the file read workers and file processor workers together. The advantage is that it lets us re-use the memory allocated for the file contents buffer, instead of allocating new memory for each file and having to garbage collect it. I explicitly drop the buffer if it's larger than `LargeByteCount` in case we end up reading any huge files.

For cases that are more CPU bound (i.e. all files are cached by the OS in memory), it benchmarks at ~8% faster for me.

For cases that are actually bound by disk IO, it's basically the same.

```
Benchmark #1: ./scc-master ~/src/linux                                                                                                                                                         
  Time (mean ± σ):     908.7 ms ±   8.9 ms    [User: 12.033 s, System: 1.171 s]
  Range (min … max):   891.5 ms … 949.1 ms    250 runs
 
Benchmark #2: ./scc-dev ~/src/linux
  Time (mean ± σ):     839.5 ms ±   7.5 ms    [User: 11.765 s, System: 0.743 s]
  Range (min … max):   820.9 ms … 868.7 ms    250 runs
 
Summary
  './scc-dev ~/src/linux' ran
    1.08 ± 0.01 times faster than './scc-master ~/src/linux'
```