### PR TITLE
Html output 139

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 		"format",
 		"f",
 		"tabular",
-		"set output format [tabular, wide, json, csv, cloc-yaml]",
+		"set output format [tabular, wide, json, csv, cloc-yaml, html, html-table]",
 	)
 	flags.StringSliceVarP(
 		&processor.AllowListExtensions,

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -283,6 +283,10 @@ func toCSV(input chan *FileJob) string {
 	return b.String()
 }
 
+func toHtml(input chan *FileJob) string {
+	return `<html lang="en"><head><meta charset="utf-8" /><title>scc html output</title></head><body>` + toHtmlTable(input) + `</body></html>`
+}
+
 func toHtmlTable(input chan *FileJob) string {
 	languages := map[string]LanguageSummary{}
 	var sumFiles, sumLines, sumCode, sumComment, sumBlank, sumComplexity int64 = 0, 0, 0, 0, 0, 0
@@ -337,29 +341,41 @@ func toHtmlTable(input chan *FileJob) string {
 
 	var str strings.Builder
 
-	str.WriteString(`<table id="scc-table"><tr>
-	<th>Language</th>
-	<th>Files</th>
-	<th>Lines</th>
-	<th>Blank</th>
-	<th>Comment</th>
-	<th>Code</th>
-	<th>Complexity</th>
-	</tr>`)
+	str.WriteString(`<table id="scc-table">
+	<thead><tr>
+		<th>Language</th>
+		<th>Files</th>
+		<th>Lines</th>
+		<th>Blank</th>
+		<th>Comment</th>
+		<th>Code</th>
+		<th>Complexity</th>
+	</tr></thead>
+	<tbody>`)
 
 	for _, r := range language {
 		str.WriteString(fmt.Sprintf(`<tr>
-	<td>%s</td>
-	<td>%d</td>
-	<td>%d</td>
-	<td>%d</td>
-	<td>%d</td>
-	<td>%d</td>
-	<td>%d</td>
+		<td>%s</td>
+		<td>%d</td>
+		<td>%d</td>
+		<td>%d</td>
+		<td>%d</td>
+		<td>%d</td>
+		<td>%d</td>
 	</tr>`, r.Name, len(r.Files), r.Lines, r.Blank, r.Comment, r.Code, r.Complexity))
 	}
 
-	str.WriteString(`</table>`)
+	str.WriteString(fmt.Sprintf(`</tbody>
+	<tfoot><tr>
+		<td>Total</td>
+		<td>%d</td>
+		<td>%d</td>
+		<td>%d</td>
+		<td>%d</td>
+		<td>%d</td>
+		<td>%d</td>
+	</tr></tfoot>
+	</table>`, sumFiles, sumLines, sumBlank, sumComment, sumCode, sumComplexity))
 
 	return str.String()
 }
@@ -375,6 +391,7 @@ func fileSummarize(input chan *FileJob) string {
 	case strings.ToLower(Format) == "csv":
 		return toCSV(input)
 	case strings.ToLower(Format) == "html":
+		return toHtml(input)
 	case strings.ToLower(Format) == "html-table":
 		return toHtmlTable(input)
 	}

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -284,7 +284,9 @@ func toCSV(input chan *FileJob) string {
 }
 
 func toHtml(input chan *FileJob) string {
-	return `<html lang="en"><head><meta charset="utf-8" /><title>scc html output</title></head><body>` + toHtmlTable(input) + `</body></html>`
+	return `<html lang="en"><head><meta charset="utf-8" /><title>scc html output</title><style>table { border-collapse: collapse; }td, th { border: 1px solid #999; padding: 0.5rem; text-align: left;}</style></head><body>` +
+		toHtmlTable(input) +
+		`</body></html>`
 }
 
 func toHtmlTable(input chan *FileJob) string {
@@ -355,25 +357,42 @@ func toHtmlTable(input chan *FileJob) string {
 
 	for _, r := range language {
 		str.WriteString(fmt.Sprintf(`<tr>
-		<td>%s</td>
-		<td>%d</td>
-		<td>%d</td>
-		<td>%d</td>
-		<td>%d</td>
-		<td>%d</td>
-		<td>%d</td>
+		<th>%s</th>
+		<th>%d</th>
+		<th>%d</th>
+		<th>%d</th>
+		<th>%d</th>
+		<th>%d</th>
+		<th>%d</th>
 	</tr>`, r.Name, len(r.Files), r.Lines, r.Blank, r.Comment, r.Code, r.Complexity))
+
+		if Files {
+			sortSummaryFiles(&r)
+
+			for _, res := range r.Files {
+				str.WriteString(fmt.Sprintf(`<tr>
+		<td>%s</td>
+		<td></td>
+		<td>%d</td>
+		<td>%d</td>
+		<td>%d</td>
+		<td>%d</td>
+		<td>%d</td>
+	</tr>`, res.Location, res.Lines, res.Blank, res.Comment, res.Code, res.Complexity))
+			}
+		}
+
 	}
 
 	str.WriteString(fmt.Sprintf(`</tbody>
 	<tfoot><tr>
-		<td>Total</td>
-		<td>%d</td>
-		<td>%d</td>
-		<td>%d</td>
-		<td>%d</td>
-		<td>%d</td>
-		<td>%d</td>
+		<th>Total</th>
+		<th>%d</th>
+		<th>%d</th>
+		<th>%d</th>
+		<th>%d</th>
+		<th>%d</th>
+		<th>%d</th>
 	</tr></tfoot>
 	</table>`, sumFiles, sumLines, sumBlank, sumComment, sumCode, sumComplexity))
 

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -26,7 +26,6 @@ var shortNameTruncate = 20
 var tabularShortFormatHeadNoComplexity = "%-22s %11s %11s %10s %11s %9s\n"
 var tabularShortFormatBodyNoComplexity = "%-22s %11d %11d %10d %11d %9d\n"
 var tabularShortFormatFileNoComplexity = "%-34s %11d %10d %11d %9d\n"
-var shortFormatFileTrucateNoComplexity = 33
 var longNameTruncate = 22
 
 var tabularWideBreak = "─────────────────────────────────────────────────────────────────────────────────────────────────────────────\n"
@@ -284,6 +283,35 @@ func toCSV(input chan *FileJob) string {
 	return b.String()
 }
 
+func toHtmlTable(input chan *FileJob) string {
+	var str strings.Builder
+
+	str.WriteString(`<table id="scc-table"><tr>
+<th>Language</th>
+<th>Filename</th>
+<th>Lines</th>
+<th>Code</th>
+<th>Comment</th>
+<th>Blank</th>
+<th>Complexity</th>
+</tr>`)
+
+	for result := range input {
+		str.WriteString(fmt.Sprintf(`<tr>
+<td>%s</td>
+<td>%s</td>
+<td>%d</td>
+<td>%d</td>
+<td>%d</td>
+<td>%d</td>
+<td>%d</td>
+</tr>`, result.Language, result.Filename, result.Lines, result.Code, result.Comment, result.Blank, result.Complexity))
+	}
+
+	str.WriteString(`</table>`)
+	return str.String()
+}
+
 func fileSummarize(input chan *FileJob) string {
 	switch {
 	case More || strings.ToLower(Format) == "wide":
@@ -294,6 +322,9 @@ func fileSummarize(input chan *FileJob) string {
 		return toClocYAML(input)
 	case strings.ToLower(Format) == "csv":
 		return toCSV(input)
+	case strings.ToLower(Format) == "html":
+	case strings.ToLower(Format) == "html-table":
+		return toHtmlTable(input)
 	}
 
 	return fileSummarizeShort(input)

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -839,6 +839,58 @@ func TestGetTabularWideBreak(t *testing.T) {
 	Ci = false
 }
 
+func TestToHTML(t *testing.T) {
+	inputChan := make(chan *FileJob, 1000)
+	inputChan <- &FileJob{
+		Language:           "Go",
+		Filename:           "bbbb.go",
+		Extension:          "go",
+		Location:           "./",
+		Bytes:              1000,
+		Lines:              1000,
+		Code:               1000,
+		Comment:            1000,
+		Blank:              1000,
+		Complexity:         1000,
+		WeightedComplexity: 1000,
+		Binary:             false,
+	}
+	close(inputChan)
+	res := toHtml(inputChan)
+
+	if !strings.Contains(res, `<html lang="en">`) {
+		t.Error("Expected to have HTML wrapper")
+	}
+}
+
+func TestToHTMLTable(t *testing.T) {
+	inputChan := make(chan *FileJob, 1000)
+	inputChan <- &FileJob{
+		Language:           "Go",
+		Filename:           "bbbb.go",
+		Extension:          "go",
+		Location:           "./",
+		Bytes:              1000,
+		Lines:              1000,
+		Code:               1000,
+		Comment:            1000,
+		Blank:              1000,
+		Complexity:         1000,
+		WeightedComplexity: 1000,
+		Binary:             false,
+	}
+	close(inputChan)
+	res := toHtmlTable(inputChan)
+
+	if strings.Contains(res, `<html lang="en">`) {
+		t.Error("Expected to not have wrapper")
+	}
+
+	if !strings.Contains(res, `<table id="scc-table">`) {
+		t.Error("Expected to have table element")
+	}
+}
+
 // When using columise  ~28726 ns/op
 // When using optimised ~14293 ns/op
 func BenchmarkFileSummerize(b *testing.B) {

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -30,6 +30,18 @@ func TestPrintError(t *testing.T) {
 	printError("Testing print error")
 }
 
+func TestPrintWarnF(t *testing.T) {
+	printWarnf("Testing print error")
+}
+
+func TestPrintDebugF(t *testing.T) {
+	printDebugf("Testing print error")
+}
+
+func TestPrintTraceF(t *testing.T) {
+	printTracef("Testing print error")
+}
+
 func TestGetFormattedTime(t *testing.T) {
 	res := getFormattedTime()
 
@@ -607,6 +619,60 @@ func TestFileSummarizeYml(t *testing.T) {
 
 	if !strings.Contains(res, `code: 1000`) {
 		t.Error("Expected YML return", res)
+	}
+}
+
+func TestFileSummarizeHtml(t *testing.T) {
+	inputChan := make(chan *FileJob, 1000)
+	inputChan <- &FileJob{
+		Language:           "Go",
+		Filename:           "bbbb.go",
+		Extension:          "go",
+		Location:           "./",
+		Bytes:              1000,
+		Lines:              1000,
+		Code:               1000,
+		Comment:            1000,
+		Blank:              1000,
+		Complexity:         1000,
+		WeightedComplexity: 1000,
+		Binary:             false,
+	}
+
+	close(inputChan)
+	Format = "html"
+	More = false
+	res := fileSummarize(inputChan)
+
+	if !strings.Contains(res, `<th>1000`) {
+		t.Error("Expected HTML return", res)
+	}
+}
+
+func TestFileSummarizeHtmlTable(t *testing.T) {
+	inputChan := make(chan *FileJob, 1000)
+	inputChan <- &FileJob{
+		Language:           "Go",
+		Filename:           "bbbb.go",
+		Extension:          "go",
+		Location:           "./",
+		Bytes:              1000,
+		Lines:              1000,
+		Code:               1000,
+		Comment:            1000,
+		Blank:              1000,
+		Complexity:         1000,
+		WeightedComplexity: 1000,
+		Binary:             false,
+	}
+
+	close(inputChan)
+	Format = "html-table"
+	More = false
+	res := fileSummarize(inputChan)
+
+	if !strings.Contains(res, `<th>1000`) {
+		t.Error("Expected HTML-table return", res)
 	}
 }
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -15,7 +15,7 @@ import (
 )
 
 // The version of the application
-var Version = "2.10.1"
+var Version = "2.11.0"
 
 // Flags set via the CLI which control how the output is displayed
 

--- a/test-all.sh
+++ b/test-all.sh
@@ -453,6 +453,24 @@ else
     exit
 fi
 
+if ./scc --format html | grep -q "html"; then
+    echo -e "${GREEN}PASSED html output test"
+else
+    echo -e "${RED}======================================================="
+    echo -e "FAILED Should be able to output to html"
+    echo -e "=======================================================${NC}"
+    exit
+fi
+
+if ./scc --format html-table | grep -q "table"; then
+    echo -e "${GREEN}PASSED html-table output test"
+else
+    echo -e "${RED}======================================================="
+    echo -e "FAILED Should be able to output to html-table"
+    echo -e "=======================================================${NC}"
+    exit
+fi
+
 # Try out specific languages
 for i in 'Bosque ' 'Flow9 ' 'Bitbucket Pipeline ' 'Docker ignore ' 'Q# ' 'Futhark ' 'Alloy ' 'Wren ' 'Monkey C ' 'Alchemist ' 'Luna ' 'ignore ' 'XML Schema ' 'Web Services' 'Go ' 'Java ' 'Boo ' 'License ' 'BASH ' 'C Shell ' 'Korn Shell ' 'Makefile ' 'Shell ' 'Zsh ' 'Rakefile ' 'Gemfile ' 'Dockerfile '
 do


### PR DESCRIPTION
Adds HTML output as an output option. I don't see too many people wanting this but it has been requested https://github.com/boyter/scc/issues/139

Supports all of the options that the command line does, except for the case of omitting complexity, although if you add that it sets it to 0 for everything.

Two modes, `html` and `html-table` where the former includes html and body tags IE a single HTML file ready to view (see screenshot) and the other which is designed to be embedded into another page and the user brings their own CSS.

![image](https://user-images.githubusercontent.com/612151/71789038-42062b80-307c-11ea-9cd2-2b350716b9b6.png)

