### PR TITLE
Add cljc file extension for Clojure

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1160,7 +1160,8 @@
       "== "
     ],
     "extensions": [
-      "clj"
+      "clj",
+      "cljc"
     ],
     "line_comment": [
       ";"


### PR DESCRIPTION
cljc files allow you to write code that is [portable between clojure dialects](https://clojure.org/guides/reader_conditionals). Many clojure projects use these files and not having them makes scc greatly under count how many lines a project has.

I explicitly licence my contribution under MIT AND The Unlicense.