### PR TITLE
Fix #172

### DIFF
--- a/processor/file.go
+++ b/processor/file.go
@@ -177,7 +177,18 @@ DIRENTS:
 				},
 			)
 		} else {
-			fileJob := newFileJob(path, name, dirent)
+			fileInfo := dirent
+			if dirent.Mode()&os.ModeSymlink != 0 {
+				linkName, err := os.Readlink(path)
+				if err != nil {
+					continue DIRENTS
+				}
+				fileInfo, err = os.Lstat(linkName)
+				if err != nil {
+					continue DIRENTS
+				}
+			}
+			fileJob := newFileJob(path, name, fileInfo)
 			if fileJob != nil {
 				dw.output <- fileJob
 			}


### PR DESCRIPTION
In short, symlinks with long paths AND contents that does not end with new lines would break the code. Following the link path gets us to actually read the file size properly and then it works. I'm not sure at all how to test this, suggestions appreciated :)

```
[11ms][~/go/src/github.com/boyter/scc]$ tree /tmp/foo 
/tmp/foo
├── bar
│   └── baz
│       └── qux
│           └── quux
│               └── quuz
│                   └── grault
│                       └── garply
│                           └── waldo
│                               └── fred
│                                   └── plugh
│                                       └── xyzzy
│                                           └── thud
│                                               └── wibble
│                                                   └── wobble
│                                                       └── wubble
│                                                           └── flob
│                                                               └── foobar.py
└── bolf
    └── elbbuw
        └── elbbow
            └── elbbiw
                └── duht
                    └── yzzyx
                        └── hgulp
                            └── derf
                                └── odlaw
                                    └── ylprag
                                        └── tluarg
                                            └── zuuq
                                                └── xuuq
                                                    └── xuq
                                                        └── zab
                                                            └── rab
                                                                ├── foobar.py -> /tmp/foo/bar/baz/qux/quux/quuz/grault/garply/waldo/fred/plugh/xyzzy/thud/wibble/wobble/wubble/flob/foobar.py
                                                                └── tmpfs
                                                                    └── foobar.py -> /tmp/foo/bar/baz/qux/quux/quuz/grault/garply/waldo/fred/plugh/xyzzy/thud/wibble/wobble/wubble/flob/foobar.py

33 directories, 3 files
[8ms][~/go/src/github.com/boyter/scc]$ # before changes
[~/go/src/github.com/boyter/scc]$ go run main.go /tmp/foo/
panic: runtime error: index out of range [9] with length 9

goroutine 9 [running]:
github.com/boyter/scc/processor.codeState(0xc0003fe0e0, 0x1, 0x6b, 0x2, 0xc00042b348, 0x0, 0x0, 0xc00042b348, 0x0, 0x0, ...)
	/home/gallois/go/src/github.com/boyter/scc/processor/workers.go:195 +0x730
github.com/boyter/scc/processor.CountStats(0xc0003fe0e0)
	/home/gallois/go/src/github.com/boyter/scc/processor/workers.go:432 +0xdca
github.com/boyter/scc/processor.processFile(0xc0003fe0e0, 0xc00041a100)
	/home/gallois/go/src/github.com/boyter/scc/processor/workers.go:708 +0x27c
github.com/boyter/scc/processor.fileProcessorWorker.func1(0xc0000664e0, 0xc000242008, 0xc000242020, 0xc000242028, 0xc000066540, 0xc000242030)
	/home/gallois/go/src/github.com/boyter/scc/processor/workers.go:649 +0x284
created by github.com/boyter/scc/processor.fileProcessorWorker
	/home/gallois/go/src/github.com/boyter/scc/processor/workers.go:625 +0xfb
exit status 2
[442ms][1][~/go/src/github.com/boyter/scc]$ # after changes         
[~/go/src/github.com/boyter/scc]$ go run main.go /tmp/foo/
───────────────────────────────────────────────────────────────────────────────
Language                 Files     Lines   Blanks  Comments     Code Complexity
───────────────────────────────────────────────────────────────────────────────
Python                       3         3        0         0        3          0
───────────────────────────────────────────────────────────────────────────────
Total                        3         3        0         0        3          0
───────────────────────────────────────────────────────────────────────────────
Estimated Cost to Develop $60
Estimated Schedule Effort 0.383061 months
Estimated People Required 0.018744
───────────────────────────────────────────────────────────────────────────────
```