### PR TITLE
Issue164

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,13 +705,13 @@ scc is pretty well tested with many unit, integration and benchmarks to ensure t
 Run go build for windows and linux then the following in linux, keep in mind need to update the version
 
 ```
-GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" && zip -r9 scc-2.13.0-x86_64-apple-darwin.zip scc
-GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" && zip -r9 scc-2.13.0-arm64-apple-darwin.zip scc
-GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" && zip -r9 scc-2.13.0-x86_64-pc-windows.zip scc.exe
-GOOS=windows GOARCH=386 go build -ldflags="-s -w" && zip -r9 scc-2.13.0-i386-pc-windows.zip scc.exe
-GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" && zip -r9 scc-2.13.0-x86_64-unknown-linux.zip scc
-GOOS=linux GOARCH=386 go build -ldflags="-s -w" && zip -r9 scc-2.13.0-i386-unknown-linux.zip scc
-GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" && zip -r9 scc-2.13.0-arm64-unknown-linux.zip scc
+GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" && zip -r9 scc-3.0.0-x86_64-apple-darwin.zip scc
+GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" && zip -r9 scc-3.0.0-arm64-apple-darwin.zip scc
+GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" && zip -r9 scc-3.0.0-x86_64-pc-windows.zip scc.exe
+GOOS=windows GOARCH=386 go build -ldflags="-s -w" && zip -r9 scc-3.0.0-i386-pc-windows.zip scc.exe
+GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" && zip -r9 scc-3.0.0-x86_64-unknown-linux.zip scc
+GOOS=linux GOARCH=386 go build -ldflags="-s -w" && zip -r9 scc-3.0.0-i386-unknown-linux.zip scc
+GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" && zip -r9 scc-3.0.0-arm64-unknown-linux.zip scc
 ```
 
 ### Containers

--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -12,12 +12,12 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>34</th>
-		<th>8333</th>
-		<th>1353</th>
-		<th>362</th>
-		<th>6618</th>
-		<th>1367</th>
-		<th>329715</th>
+		<th>8378</th>
+		<th>1357</th>
+		<th>370</th>
+		<th>6651</th>
+		<th>1390</th>
+		<th>331412</th>
 	</tr><tr>
 		<th>Java</th>
 		<th>24</th>
@@ -40,11 +40,11 @@
 		<th>Markdown</th>
 		<th>11</th>
 		<th>1228</th>
-		<th>296</th>
 		<th>0</th>
-		<th>932</th>
 		<th>0</th>
-		<th>49896</th>
+		<th>1228</th>
+		<th>0</th>
+		<th>49889</th>
 	</tr><tr>
 		<th>Python</th>
 		<th>9</th>
@@ -67,9 +67,9 @@
 		<th>License</th>
 		<th>5</th>
 		<th>55</th>
-		<th>12</th>
 		<th>0</th>
-		<th>43</th>
+		<th>0</th>
+		<th>55</th>
 		<th>0</th>
 		<th>3425</th>
 	</tr><tr>
@@ -130,9 +130,9 @@
 		<th>Plain Text</th>
 		<th>2</th>
 		<th>31</th>
-		<th>7</th>
 		<th>0</th>
-		<th>24</th>
+		<th>0</th>
+		<th>31</th>
 		<th>0</th>
 		<th>1474</th>
 	</tr><tr>
@@ -363,12 +363,12 @@
 	</tr><tr>
 		<th>HTML</th>
 		<th>1</th>
-		<th>572</th>
+		<th>581</th>
 		<th>0</th>
 		<th>0</th>
-		<th>572</th>
+		<th>581</th>
 		<th>0</th>
-		<th>8387</th>
+		<th>8506</th>
 	</tr><tr>
 		<th>JSON</th>
 		<th>1</th>
@@ -571,11 +571,11 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>168</th>
-		<th>25426</th>
-		<th>2892</th>
-		<th>1682</th>
-		<th>20852</th>
-		<th>2310</th>
-    	<th>1768235</th>
+		<th>25480</th>
+		<th>2581</th>
+		<th>1690</th>
+		<th>21209</th>
+		<th>2333</th>
+    	<th>1770044</th>
 	</tr></tfoot>
 	</table></body></html>

--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -12,12 +12,12 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>34</th>
-		<th>8378</th>
-		<th>1357</th>
+		<th>8383</th>
+		<th>1358</th>
 		<th>370</th>
-		<th>6651</th>
-		<th>1390</th>
-		<th>331412</th>
+		<th>6655</th>
+		<th>1391</th>
+		<th>331515</th>
 	</tr><tr>
 		<th>Java</th>
 		<th>24</th>
@@ -571,11 +571,11 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>168</th>
-		<th>25480</th>
-		<th>2581</th>
+		<th>25485</th>
+		<th>2582</th>
 		<th>1690</th>
-		<th>21209</th>
-		<th>2333</th>
-    	<th>1770044</th>
+		<th>21213</th>
+		<th>2334</th>
+    	<th>1770147</th>
 	</tr></tfoot>
 	</table></body></html>

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -358,6 +358,13 @@ func processLanguageFeature(name string, value Language) {
 	}
 	processMask |= stringMask
 
+	simple := false
+	// if there is nothing to check IE no complexity, no comments and no quotes we can mark this as a simple
+	// file like text or some such and speed up processing of this file type
+	if len(value.ComplexityChecks) == 0 && len(value.LineComment) == 0 && len(value.MultiLine) == 0 && len(value.Quotes) == 0 {
+		simple = true
+	}
+
 	LanguageFeaturesMutex.Lock()
 	LanguageFeatures[name] = LanguageFeature{
 		Complexity:            complexityTrie,
@@ -373,6 +380,7 @@ func processLanguageFeature(name string, value Language) {
 		ProcessMask:           processMask,
 		Keywords:              value.Keywords,
 		Quotes:                value.Quotes,
+		Simple:                simple,
 	}
 	LanguageFeaturesMutex.Unlock()
 }

--- a/processor/structs.go
+++ b/processor/structs.go
@@ -50,6 +50,7 @@ type LanguageFeature struct {
 	ProcessMask           byte
 	Keywords              []string
 	Quotes                []Quote
+	Simple                bool // indicates that this is like a text file and can be counted more quickly
 }
 
 // FileJobCallback is an interface that FileJobs can implement to get a per line callback with the line type

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -440,6 +440,11 @@ func CountStats(fileJob *FileJob) {
 				return
 			}
 
+			if Duplicates {
+				digestible := []byte{fileJob.Content[index]}
+				digest.Write(digestible)
+			}
+
 			if fileJob.Content[index] == '\n' || index >= endPoint {
 				fileJob.Code++
 				fileJob.Lines++


### PR DESCRIPTION
Very small performance tweak on some workloads. For languages identified as "simple" which means there is nothing to count, flip into simple mode and skip all of the logic of the state engine. This is mostly in preparation of having custom state machines for more common languages which will follow the same ideas hence being a bit ugly.

```
$ hyperfine -m 250 'scc' './scc'
Benchmark #1: scc
  Time (mean ± σ):      37.9 ms ±   3.1 ms    [User: 111.0 ms, System: 78.8 ms]
  Range (min … max):    31.0 ms …  43.5 ms    250 runs
 
Benchmark #2: ./scc
  Time (mean ± σ):      37.0 ms ±   3.7 ms    [User: 111.5 ms, System: 78.3 ms]
  Range (min … max):    30.3 ms …  60.8 ms    250 runs
 
Summary
  './scc' ran
    1.02 ± 0.13 times faster than 'scc'
```