### PR TITLE
Clean up new bloom filter implementation

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -357,7 +357,7 @@ func processLanguageFeature(name string, value Language) {
 	var processMask uint64
 
 	for _, v := range value.ComplexityChecks {
-		complexityMask |= BloomHash(v[0])
+		complexityMask |= BloomTable[v[0]]
 		complexityTrie.Insert(TComplexity, []byte(v))
 		if !Complexity {
 			tokenTrie.Insert(TComplexity, []byte(v))
@@ -368,21 +368,21 @@ func processLanguageFeature(name string, value Language) {
 	}
 
 	for _, v := range value.LineComment {
-		singleLineCommentMask |= BloomHash(v[0])
+		singleLineCommentMask |= BloomTable[v[0]]
 		slCommentTrie.Insert(TSlcomment, []byte(v))
 		tokenTrie.Insert(TSlcomment, []byte(v))
 	}
 	processMask |= singleLineCommentMask
 
 	for _, v := range value.MultiLine {
-		multiLineCommentMask |= BloomHash(v[0][0])
+		multiLineCommentMask |= BloomTable[v[0][0]]
 		mlCommentTrie.InsertClose(TMlcomment, []byte(v[0]), []byte(v[1]))
 		tokenTrie.InsertClose(TMlcomment, []byte(v[0]), []byte(v[1]))
 	}
 	processMask |= multiLineCommentMask
 
 	for _, v := range value.Quotes {
-		stringMask |= BloomHash(v.Start[0])
+		stringMask |= BloomTable[v.Start[0]]
 		stringTrie.InsertClose(TString, []byte(v.Start), []byte(v.End))
 		tokenTrie.InsertClose(TString, []byte(v.Start), []byte(v.End))
 	}


### PR DESCRIPTION
Cleaned up to use `math/rand` to distribute the numbers rather than handrolled maths.

It seems like the better number distribution leads to a slightly more efficient bloom filter (as I suspected). It's not a huge improvement, but 2-3% faster is still a win.

```
Benchmark #1: ./scc-master ../../torvalds/linux
  Time (mean ± σ):     699.7 ms ±   7.6 ms    [User: 9.277 s, System: 0.908 s]
  Range (min … max):   683.8 ms … 716.0 ms    50 runs

Benchmark #2: ./scc-bloom2 ../../torvalds/linux
  Time (mean ± σ):     678.1 ms ±   9.5 ms    [User: 8.846 s, System: 0.929 s]
  Range (min … max):   653.0 ms … 698.4 ms    50 runs

Summary
  './scc-bloom2 ../../torvalds/linux' ran
    1.03 ± 0.02 times faster than './scc-master ../../torvalds/linux'
```