### PR TITLE
Upgrade imports to match module version

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/boyter/scc/processor"
+	"github.com/boyter/scc/v3/processor"
 )
 
 type statsProcessor struct{}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/boyter/scc
+module github.com/boyter/scc/v3
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/boyter/scc/processor"
+	"github.com/boyter/scc/v3/processor"
 	"github.com/spf13/cobra"
 	"os"
 )

--- a/processor/file.go
+++ b/processor/file.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/boyter/scc/processor/gitignore"
+	"github.com/boyter/scc/v3/processor/gitignore"
 	"github.com/dbaggerman/cuba"
 )
 


### PR DESCRIPTION
Fixes https://github.com/boyter/scc/issues/237.

```
go get -u github.com/boyter/scc@v3.0.0
go get: github.com/boyter/scc@v3.0.0: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v3
```

This PR upgrades imports to include [SIV](https://github.com/golang/go/wiki/Modules#semantic-import-versioning) so that latest version can be imported as a module.

After merging, new minor or patch version (e.g. `v3.0.1`) can be tagged to solve the original issue.
