### PR TITLE
Avoid reading non-regular files.

### DIFF
--- a/processor/file.go
+++ b/processor/file.go
@@ -234,6 +234,15 @@ func newFileJob(path, name string, fileInfo os.FileInfo) *FileJob {
 		fileInfo, _ = os.Lstat(symPath)
 	}
 
+	// Skip non-regular files. They are unlikely to be code and may hang if we
+	// try and read them.
+	if !fileInfo.Mode().IsRegular() {
+		if Verbose {
+			printWarn(fmt.Sprintf("skipping non-regular file: %s", path))
+		}
+		return nil
+	}
+
 	language, extension := DetectLanguage(name)
 
 	if len(language) != 0 {


### PR DESCRIPTION
If we try and read things like fifos we can block indefinitely trying to read. So we want to avoid reading them. Other non-regular files (other than directories and symlinks) are likely to also be weird in other ways. 

As the code above this deals with symlinks and directories are expected to already be excluded I think skipping non-regular files is reasonable.

I couldn't get the tests to work on my machine before this change so I don't know if this passes them or not. There may be weird cases I haven't thought about that the tests cover.