### PR TITLE
Add a command line argument for the currency symbol for cost estimation

### DIFF
--- a/main.go
+++ b/main.go
@@ -294,6 +294,12 @@ func main() {
 		"",
 		"inspect every file and remap by checking for a string and remapping the language [e.g. \"-*- C++ -*-\":\"C Header\"]",
 	)
+	flags.StringVar(
+		&processor.CurrencySymbol,
+		"currency-symbol",
+		"$",
+		"set currency symbol",
+	)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -998,7 +998,7 @@ func calculateCocomo(sumCode int64, str *strings.Builder) {
 
 		p := gmessage.NewPrinter(glang.English)
 
-		str.WriteString(p.Sprintf("Estimated Cost to Develop (%s) $%d\n", CocomoProjectType, int64(estimatedCost)))
+		str.WriteString(p.Sprintf("Estimated Cost to Develop (%s) %s%d\n", CocomoProjectType, CurrencySymbol, int64(estimatedCost)))
 		str.WriteString(fmt.Sprintf("Estimated Schedule Effort (%s) %f months\n", CocomoProjectType, estimatedScheduleMonths))
 		if math.IsNaN(estimatedPeopleRequired) {
 			str.WriteString(fmt.Sprintf("Estimated People Required 1 Grandparent\n"))

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -118,6 +118,9 @@ var RemapUnknown = ""
 // RemapAll allows remapping of all files with a string to search the content for
 var RemapAll = ""
 
+// CurrencySymbol allows setting the currency symbol for cocomo project cost estimation
+var CurrencySymbol = ""
+
 // FileOutput sets the file that output should be written to
 var FileOutput = ""
 


### PR DESCRIPTION
See topic. Allows `scc --currency-symbol ¥ .` to output e.g. `Estimated Cost to Develop (organic) ¥665,931`