### PR TITLE
Add a overhead commandline flag to set the multiplier for corporate overhead. #281

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,6 +108,12 @@ func main() {
 		56286,
 		"average wage value used for basic COCOMO calculation",
 	)
+	flags.Float64Var(
+		&processor.Overhead,
+		"overhead",
+		2.4,
+		"set the overhead multiplier for corporate overhead (facilities, equipment, accounting, etc.)",
+	)
 	flags.BoolVar(
 		&processor.Cocomo,
 		"no-cocomo",

--- a/processor/cocomo.go
+++ b/processor/cocomo.go
@@ -27,8 +27,8 @@ var projectType = map[string][]float64{
 
 // EstimateCost calculates the cost in dollars applied using generic COCOMO weighted values based
 // on the average yearly wage
-func EstimateCost(effortApplied float64, averageWage int64) float64 {
-	return effortApplied * float64(averageWage/12) * 2.4
+func EstimateCost(effortApplied float64, averageWage int64, overhead float64) float64 {
+	return effortApplied * float64(averageWage/12) * overhead
 }
 
 // EstimateEffort calculate the effort applied using generic COCOMO weighted values

--- a/processor/cocomo_test.go
+++ b/processor/cocomo_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestEstimateCost(t *testing.T) {
 	eff := EstimateEffort(26)
-	got := EstimateCost(eff, 56000)
+	got := EstimateCost(eff, 56000, 2.4)
 
 	// Should be around 582
 	if got < 580 || got > 585 {
@@ -18,7 +18,7 @@ func TestEstimateCost(t *testing.T) {
 
 func TestEstimateCostManyLines(t *testing.T) {
 	eff := EstimateEffort(77873)
-	got := EstimateCost(eff, 56000)
+	got := EstimateCost(eff, 56000, 2.4)
 
 	// Should be around 2602096
 	if got < 2602000 || got > 2602100 {

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -817,7 +817,7 @@ func fileSummarizeLong(input chan *FileJob) string {
 
 	if !Cocomo {
 		estimatedEffort := EstimateEffort(int64(sumCode))
-		estimatedCost := EstimateCost(estimatedEffort, AverageWage)
+		estimatedCost := EstimateCost(estimatedEffort, AverageWage, Overhead)
 		estimatedScheduleMonths := EstimateScheduleMonths(estimatedEffort)
 		estimatedPeopleRequired := estimatedEffort / estimatedScheduleMonths
 
@@ -992,7 +992,7 @@ func trimNameShort(summary LanguageSummary, trimmedName string) string {
 func calculateCocomo(sumCode int64, str *strings.Builder) {
 	if !Cocomo {
 		estimatedEffort := EstimateEffort(int64(sumCode))
-		estimatedCost := EstimateCost(estimatedEffort, AverageWage)
+		estimatedCost := EstimateCost(estimatedEffort, AverageWage, Overhead)
 		estimatedScheduleMonths := EstimateScheduleMonths(estimatedEffort)
 		estimatedPeopleRequired := estimatedEffort / estimatedScheduleMonths
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -145,6 +145,9 @@ var AllowListExtensions = []string{}
 // AverageWage is the average wage in dollars used for the COCOMO cost estimate
 var AverageWage int64 = 56286
 
+// Overhead is the overhead multiplier for corporate overhead (facilities, equipment, accounting, etc.)
+var Overhead float64 = 2.4
+
 // GcFileCount is the number of files to process before turning the GC back on
 var GcFileCount = 10000
 var gcPercent = -1


### PR DESCRIPTION
This commit makes the hard-coded overhead factor of 2.4 configurable by command line argument. Issue #281 is maybe related.