### PR TITLE
Add a command line argument for the effort adjustment factor.

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,6 +114,12 @@ func main() {
 		2.4,
 		"set the overhead multiplier for corporate overhead (facilities, equipment, accounting, etc.)",
 	)
+	flags.Float64Var(
+		&processor.EAF,
+		"eaf",
+		1.0,
+		"the effort adjustment factor derived from the cost drivers (1.0 if rated nominal)",
+	)
 	flags.BoolVar(
 		&processor.Cocomo,
 		"no-cocomo",

--- a/processor/cocomo.go
+++ b/processor/cocomo.go
@@ -32,8 +32,7 @@ func EstimateCost(effortApplied float64, averageWage int64, overhead float64) fl
 }
 
 // EstimateEffort calculate the effort applied using generic COCOMO weighted values
-func EstimateEffort(sloc int64) float64 {
-	var eaf float64 = 1
+func EstimateEffort(sloc int64, eaf float64) float64 {
 	var effortApplied = projectType[CocomoProjectType][0] * math.Pow(float64(sloc)/1000, projectType[CocomoProjectType][1]) * eaf
 	return effortApplied
 }

--- a/processor/cocomo_test.go
+++ b/processor/cocomo_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestEstimateCost(t *testing.T) {
-	eff := EstimateEffort(26)
+	eff := EstimateEffort(26, 1)
 	got := EstimateCost(eff, 56000, 2.4)
 
 	// Should be around 582
@@ -17,7 +17,7 @@ func TestEstimateCost(t *testing.T) {
 }
 
 func TestEstimateCostManyLines(t *testing.T) {
-	eff := EstimateEffort(77873)
+	eff := EstimateEffort(77873, 1)
 	got := EstimateCost(eff, 56000, 2.4)
 
 	// Should be around 2602096
@@ -27,7 +27,7 @@ func TestEstimateCostManyLines(t *testing.T) {
 }
 
 func TestEstimateScheduleMonths(t *testing.T) {
-	eff := EstimateEffort(537)
+	eff := EstimateEffort(537, 1)
 	got := EstimateScheduleMonths(eff)
 
 	// Should be around 2.7

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -816,7 +816,7 @@ func fileSummarizeLong(input chan *FileJob) string {
 	str.WriteString(getTabularWideBreak())
 
 	if !Cocomo {
-		estimatedEffort := EstimateEffort(int64(sumCode))
+		estimatedEffort := EstimateEffort(int64(sumCode), EAF)
 		estimatedCost := EstimateCost(estimatedEffort, AverageWage, Overhead)
 		estimatedScheduleMonths := EstimateScheduleMonths(estimatedEffort)
 		estimatedPeopleRequired := estimatedEffort / estimatedScheduleMonths
@@ -991,7 +991,7 @@ func trimNameShort(summary LanguageSummary, trimmedName string) string {
 
 func calculateCocomo(sumCode int64, str *strings.Builder) {
 	if !Cocomo {
-		estimatedEffort := EstimateEffort(int64(sumCode))
+		estimatedEffort := EstimateEffort(int64(sumCode), EAF)
 		estimatedCost := EstimateCost(estimatedEffort, AverageWage, Overhead)
 		estimatedScheduleMonths := EstimateScheduleMonths(estimatedEffort)
 		estimatedPeopleRequired := estimatedEffort / estimatedScheduleMonths

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -148,6 +148,9 @@ var AverageWage int64 = 56286
 // Overhead is the overhead multiplier for corporate overhead (facilities, equipment, accounting, etc.)
 var Overhead float64 = 2.4
 
+// the effort adjustment factor derived from the cost drivers, i.e. 1.0 if rated nominal
+var EAF float64 = 1.0
+
 // GcFileCount is the number of files to process before turning the GC back on
 var GcFileCount = 10000
 var gcPercent = -1


### PR DESCRIPTION
Here is another one for the effort adjustment factor (EAF). The EAF can be used to set deviating cost drivers with the predefined project type.

For example, if your project is rated (according to [dwheeler cost driver table](https://dwheeler.com/sloccount/sloccount.html#cocomo)) Very High for Complexity (effort multiplier of 1.30), and Low for Language & Tools Experience (effort multiplier of 1.07), and all of the other cost drivers are rated to be Nominal (effort multiplier of 1.00), the EAF is the product of 1.30 and 1.07.

Effort Adjustment Factor = EAF = 1.30 * 1.07 = 1.391

 `scc --cocomo-project-type "organic" --eaf 1.391`

The eaf was hard-coded to a factor of 1 beforehand.