### PR TITLE
Unify output of fileSummarizeShort() and fileSummarizeLong() and simple language support for number formats

### DIFF
--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/mattn/go-runewidth"
 
-	glang "golang.org/x/text/language"
+	"golang.org/x/text/language"
 	gmessage "golang.org/x/text/message"
 	"gopkg.in/yaml.v2"
 )
@@ -993,14 +993,14 @@ func calculateCocomo(sumCode int64, str *strings.Builder) {
 	estimatedScheduleMonths := EstimateScheduleMonths(estimatedEffort)
 	estimatedPeopleRequired := estimatedEffort / estimatedScheduleMonths
 
-	p := gmessage.NewPrinter(glang.English)
+	p := gmessage.NewPrinter(language.Make(os.Getenv("LANG")))
 
 	str.WriteString(p.Sprintf("Estimated Cost to Develop (%s) %s%d\n", CocomoProjectType, CurrencySymbol, int64(estimatedCost)))
-	str.WriteString(fmt.Sprintf("Estimated Schedule Effort (%s) %f months\n", CocomoProjectType, estimatedScheduleMonths))
+	str.WriteString(p.Sprintf("Estimated Schedule Effort (%s) %f months\n", CocomoProjectType, estimatedScheduleMonths))
 	if math.IsNaN(estimatedPeopleRequired) {
-		str.WriteString(fmt.Sprintf("Estimated People Required 1 Grandparent\n"))
+		str.WriteString(p.Sprintf("Estimated People Required 1 Grandparent\n"))
 	} else {
-		str.WriteString(fmt.Sprintf("Estimated People Required (%s) %f\n", CocomoProjectType, estimatedPeopleRequired))
+		str.WriteString(p.Sprintf("Estimated People Required (%s) %f\n", CocomoProjectType, estimatedPeopleRequired))
 	}
 }
 

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -701,6 +701,7 @@ func fileSummarizeLong(input chan *FileJob) string {
 		sumComment += res.Comment
 		sumBlank += res.Blank
 		sumComplexity += res.Complexity
+		sumBytes += res.Bytes
 
 		var weightedComplexity float64
 		if res.Code != 0 {


### PR DESCRIPTION
Basically this fixes a inconsistency in fileSummarizeShort() and fileSummarizeLong() and adds i18n support for number formats i.e. decimal and thousands separators.

```
$>./scc
...
Estimated Cost to Develop (organic) $667,319
Estimated Schedule Effort (organic) 11.79 months
Estimated People Required (organic) 5.03

$>LANG=de ./scc
...
Estimated Cost to Develop (organic) $667.319
Estimated Schedule Effort (organic) 11,79 months
Estimated People Required (organic) 5,03
```

At the moment I'm thinking about refactoring the COCOMO output to SLOCCount's output format, i.e. writing out the formula for calculating the values for better understanding of the printed values. But I'm unsure if this is something for a PR or a private branch...