### PR TITLE
Add --sloccount-format flag to print a more SLOCCount like COCOMO calculation

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,9 +4,10 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/boyter/scc/v3/processor"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 //go:generate go run scripts/include.go
@@ -119,6 +120,12 @@ func main() {
 		"eaf",
 		1.0,
 		"the effort adjustment factor derived from the cost drivers (1.0 if rated nominal)",
+	)
+	flags.BoolVar(
+		&processor.SLOCCountFormat,
+		"sloccount-format",
+		false,
+		"print a more SLOCCount like COCOMO calculation",
 	)
 	flags.BoolVar(
 		&processor.Cocomo,

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -1009,6 +1009,7 @@ func calcolateCocomoSLOCCount(sumCode int64, str *strings.Builder) {
 	str.WriteString(p.Sprintf(" (Basic COCOMO model, Months = %.2f*(person-months**%.2f))\n", projectType[CocomoProjectType][2], projectType[CocomoProjectType][3]))
 	str.WriteString(p.Sprintf("Estimated Average Number of Developers (Effort/Schedule)       = %.2f\n", estimatedPeopleRequired))
 	str.WriteString(p.Sprintf("Total Estimated Cost to Develop                                = %s%.0f\n", CurrencySymbol, estimatedCost))
+	str.WriteString(p.Sprintf(" (average salary = %s%d/year, overhead = %.2f)\n", CurrencySymbol, AverageWage, Overhead))
 }
 
 func calculateCocomo(sumCode int64, str *strings.Builder) {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -5,7 +5,6 @@ package processor
 import (
 	"encoding/base64"
 	"fmt"
-	jsoniter "github.com/json-iterator/go"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -15,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 // Version indicates the version of the application
@@ -72,6 +73,9 @@ var More = false
 
 // Cocomo toggles the COCOMO calculation
 var Cocomo = false
+
+// Print a more SLOCCount like COCOMO calculation
+var SLOCCountFormat = false
 
 // CocomoProjectType allows the flipping between project types which impacts the calculation
 var CocomoProjectType = "organic"


### PR DESCRIPTION
As mentioned in the previous PR, I've added a flag to output a more SLOCCount like COCOMO calculation. I prefer this one because you can see the formula and values used.