### PR TITLE
Update documentation about Github action

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get the lines of code.
         id: scc
-        uses: iryanbell/scc-docker-action@v1.0.0
+        uses: iryanbell/scc-docker-action@v1.0.2
         with:
           args: ${{ env.workspace }} -i js,go,html,css
 ```


### PR DESCRIPTION
Updating the Github action tag, because there is an issue in `1.0.0` exporting the `scc` output into the Gtihub action steps.