### PR TITLE
added Raku info to languages.json

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -2157,10 +2157,10 @@
       "and",
       "or",
       "xor",
-      
+
       "eq",
       "=",
-      
+
       "smart-if",
       "smart-if*",
       "smart-when",
@@ -4499,7 +4499,7 @@
     "line_comment": [
       "%"
     ],
-    "multi_line": [ 
+    "multi_line": [
       [
         "%{",
         "}%"
@@ -4801,7 +4801,7 @@
     "line_comment": [
       "//"
     ],
-    "multi_line": [ 
+    "multi_line": [
       [
         "/*",
         "*/"
@@ -5149,8 +5149,7 @@
     ],
     "shebangs": [
       "perl",
-      "perl5",
-      "perl6"
+      "perl5"
     ]
   },
   "Plain Text": {
@@ -5682,6 +5681,148 @@
         "end": "'",
         "start": "'"
       }
+    ]
+  },
+  "Raku": {
+    "complexitychecks": [
+      "== ",
+      "≡ ",
+      "!= ",
+      "≠ ",
+      "!== ",
+      "≢ ",
+      "< ",
+      "⊂ ",
+      "!< ",
+      "⊄ ",
+      "<= ",
+      "≤ ",
+      "⊆ ",
+      "!<= ",
+      "⊈ ",
+      "> ",
+      "⊃ ",
+      "!> ",
+      "⊅ ",
+      ">= ",
+      "≥ ",
+      "⊇ ",
+      "!>= ",
+      "⊉ ",
+      "=~= ",
+      "≅ ",
+      "=== ",
+      "eq ",
+      "!eq ",
+      "eqv ",
+      "ne ",
+      "gt ",
+      "ge ",
+      "lt ",
+      "le ",
+      "=:=",
+      "CATCH ",
+      "CONTROL ",
+      "DOC ",
+      "NEXT ",
+      "and ",
+      "default ",
+      "do {",
+      "else ",
+      "elsif ",
+      "emit ",
+      "for ",
+      "gather ",
+      "given ",
+      "if ",
+      "last ",
+      "loop (",
+      "next ",
+      "once ",
+      "or ",
+      "orwith ",
+      "react {",
+      "redo ",
+      "repeat ",
+      "start {",
+      "supply ",
+      "unless ",
+      "until ",
+      "when ",
+      "whenever ",
+      "while ",
+      "with ",
+      "without "
+    ],
+    "extensions": [
+      "raku",
+      "rakumod",
+      "rakutest",
+      "rakudoc",
+      "t"
+    ],
+    "line_comment": [
+      "#"
+    ],
+    "multi_line": [
+      [
+        "=begin",
+        "=end"
+      ],
+      [
+        "#`(",
+        ")"
+      ],
+      [
+        "#`[",
+        "]"
+      ],
+      [
+        "#`{",
+        "}"
+      ],
+      [
+        "#`｢",
+        "｣"
+      ]
+
+    ],
+    "quotes": [
+      {
+        "end": "\\\"",
+        "start": "\\\""
+      },
+      {
+        "end": "'",
+        "start": "'"
+      },
+      {
+        "end": "“",
+        "start": "„"
+      },
+      {
+        "end": "»",
+        "start": "«"
+      },
+      {
+        "end": ">>",
+        "start": "<<"
+      },
+      {
+        "end": "”",
+        "start": "“"
+      },
+      {
+        "end": "‘",
+        "start": "’"
+      },
+      {
+        "end": "｣",
+        "start": "｢"
+      }
+    ],
+    "shebangs": [
+      "raku"
     ]
   },
   "Razor": {


### PR DESCRIPTION
Fixes Issue #362 

## source refereneces
Source for 99% of the complexity stuff [is here in the Raku docs](https://docs.raku.org/language/control)

The all-caps ones are [Phasers](https://docs.raku.org/language/phasers) and I _think_ they should be included but I'm not 100% sure.

All the various quote marks come from [here in the grammar](https://github.com/rakudo/rakudo/blob/b5df6e28c4b1ebd2980174342c616e543c49a233/src/Perl6/Grammar.nqp#L3481)

except for `«` and `»` which are actually defined a few times in a few ways in the grammar (context alters meaning) Sometimes they function as quote marks. Sometimes they're...more. 

[edit]: added `react` and `whenever` from [the concurrency docs](https://docs.raku.org/language/concurrency#react).

## Notes 
Also of note is "emit" which is in the flow control docs but wasn't clear if it should be included for the complexity check or not.

I've also specifically not included tests like `<` and `lt` because other languages seemed to not include those. 

I've also removed perl6 from the shebang list
for perl since perl6 is a different language
(now called raku).

⚠️ there is overlap between Perl and Raku with regards to some extensions. As noted in issue #362

> The old .p6 (or .pl6), .pm6 (or .pm which is also supported, but discouraged) and .pod6 extensions will continue to be supported for 6.e and marked as deprecated in 6.f. We're currently at v6.d so we've got a while before those are officially deprecated. That being said, you're not going to find them in any new codebases so I'm not sure anyone would care.

My recommendation would be to remove those from this PR because no-one's using them anymore and a fair amount of that ancient code with old extensions doesn't work anymore anyways. Just holler and I'll make that change.

## License Declaration
I Kay Rhodes (a.k.a masukomi) explicitly license this contribution under the MIT AND Unlicense licenses. 