### PR TITLE
update Julia complexity checks

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -3644,13 +3644,15 @@
       "for(",
       "if ",
       "if(",
-      "switch ",
       "while ",
       "else ",
+      "elseif ",
+      "elseif(",
+      "try ",
+      "catch ",
+      "finally ",
       "|| ",
-      "&& ",
-      "!= ",
-      "== "
+      "&& "
     ],
     "extensions": [
       "jl"


### PR DESCRIPTION
The Julia complexity checks included a `switch` statement (which [does not currently exist](https://github.com/JuliaLang/julia/issues/18285) in Julia) but omitted `elseif` and `try/catch/finally` (unlike Python). 

Also, the Julia checks oddly included two comparison operators `==` and `!=`, which are not control flow (unlike the short-circuiting `&&` and `||`), are only two of the *many* comparison operators in Julia, and don't seem to be used as complexity measures by scc for Python.  So I deleted these two from the list.   Is there a good argument for why these should be included?   (I see that a number of languages, like Ruby and C++, do include them for some reason.) 

I also considered adding Julia's `->` and `do` operators which create [anonymous functions](https://docs.julialang.org/en/v1/manual/functions/#man-anonymous-functions), but you don't use the analogous `lambda` in Python so I left it out.