### PR TITLE
Make OpenMetrics output spec compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,15 +627,12 @@ The output includes a metadata header containing definitions of the returned met
 # UNIT scc_lines lines
 # HELP scc_lines Number of lines.
 # TYPE scc_code count
-# UNIT scc_code lines
 # HELP scc_code Number of lines of actual code.
 # TYPE scc_comments count
 # HELP scc_comments Number of comments.
 # TYPE scc_blanks count
-# UNIT scc_blanks lines
 # HELP scc_blanks Number of blank lines.
 # TYPE scc_complexity count
-# UNIT scc_complexity lines
 # HELP scc_complexity Code complexity.
 # TYPE scc_bytes count
 # UNIT scc_bytes bytes
@@ -655,12 +652,12 @@ scc_bytes{language="Go"} 1000
 
 or, if `--by-file` is present, in per file form:
 ```text
-scc_lines{language="Go", file="./bbbb.go"} 1000
-scc_code{language="Go", file="./bbbb.go"} 1000
-scc_comments{language="Go", file="./bbbb.go"} 1000
-scc_blanks{language="Go", file="./bbbb.go"} 1000
-scc_complexity{language="Go", file="./bbbb.go"} 1000
-scc_bytes{language="Go", file="./bbbb.go"} 1000
+scc_lines{language="Go",file="./bbbb.go"} 1000
+scc_code{language="Go",file="./bbbb.go"} 1000
+scc_comments{language="Go",file="./bbbb.go"} 1000
+scc_blanks{language="Go",file="./bbbb.go"} 1000
+scc_complexity{language="Go",file="./bbbb.go"} 1000
+scc_bytes{language="Go",file="./bbbb.go"} 1000
 ```
 
 ### Performance

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -46,25 +46,21 @@ var wideFormatFileTruncate = 42
 var openMetricsMetadata = `# TYPE scc_files count
 # HELP scc_files Number of sourcecode files.
 # TYPE scc_lines count
-# UNIT scc_lines lines
 # HELP scc_lines Number of lines.
 # TYPE scc_code count
-# UNIT scc_code lines
 # HELP scc_code Number of lines of actual code.
 # TYPE scc_comments count
 # HELP scc_comments Number of comments.
 # TYPE scc_blanks count
-# UNIT scc_blanks lines
 # HELP scc_blanks Number of blank lines.
 # TYPE scc_complexity count
-# UNIT scc_complexity lines
 # HELP scc_complexity Code complexity.
 # TYPE scc_bytes count
 # UNIT scc_bytes bytes
 # HELP scc_bytes Size in bytes.
 `
 var openMetricsSummaryRecordFormat = "scc_%s{language=\"%s\"} %d\n"
-var openMetricsFileRecordFormat = "scc_%s{language=\"%s\", file=\"%s\"} %d\n"
+var openMetricsFileRecordFormat = "scc_%s{language=\"%s\",file=\"%s\"} %d\n"
 
 func sortSummaryFiles(summary *LanguageSummary) {
 	switch {
@@ -461,6 +457,7 @@ func toOpenMetricsFiles(input chan *FileJob) string {
 		sb.WriteString(fmt.Sprintf(openMetricsFileRecordFormat, "complexity", file.Language, filename, file.Complexity))
 		sb.WriteString(fmt.Sprintf(openMetricsFileRecordFormat, "bytes", file.Language, filename, file.Bytes))
 	}
+	sb.WriteString("# EOF")
 	return sb.String()
 }
 

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -743,15 +743,12 @@ func TestToOpenMetricsMultiple(t *testing.T) {
 # UNIT scc_lines lines
 # HELP scc_lines Number of lines.
 # TYPE scc_code count
-# UNIT scc_code lines
 # HELP scc_code Number of lines of actual code.
 # TYPE scc_comments count
 # HELP scc_comments Number of comments.
 # TYPE scc_blanks count
-# UNIT scc_blanks lines
 # HELP scc_blanks Number of blank lines.
 # TYPE scc_complexity count
-# UNIT scc_complexity lines
 # HELP scc_complexity Code complexity.
 # TYPE scc_bytes count
 # UNIT scc_bytes bytes
@@ -763,6 +760,7 @@ scc_comments{language="Go"} 2000
 scc_blanks{language="Go"} 2000
 scc_complexity{language="Go"} 2000
 scc_bytes{language="Go"} 2000
+# EOF
 `
 
 	if res != expectedResult {
@@ -979,15 +977,12 @@ func TestFileSummarizeOpenMetrics(t *testing.T) {
 # UNIT scc_lines lines
 # HELP scc_lines Number of lines.
 # TYPE scc_code count
-# UNIT scc_code lines
 # HELP scc_code Number of lines of actual code.
 # TYPE scc_comments count
 # HELP scc_comments Number of comments.
 # TYPE scc_blanks count
-# UNIT scc_blanks lines
 # HELP scc_blanks Number of blank lines.
 # TYPE scc_complexity count
-# UNIT scc_complexity lines
 # HELP scc_complexity Code complexity.
 # TYPE scc_bytes count
 # UNIT scc_bytes bytes
@@ -999,6 +994,7 @@ scc_comments{language="Go"} 1000
 scc_blanks{language="Go"} 1000
 scc_complexity{language="Go"} 1000
 scc_bytes{language="Go"} 1000
+# EOF
 `
 
 	if res != expectedResult {
@@ -1035,25 +1031,22 @@ func TestFileSummarizeOpenMetricsPerFile(t *testing.T) {
 # UNIT scc_lines lines
 # HELP scc_lines Number of lines.
 # TYPE scc_code count
-# UNIT scc_code lines
 # HELP scc_code Number of lines of actual code.
 # TYPE scc_comments count
 # HELP scc_comments Number of comments.
 # TYPE scc_blanks count
-# UNIT scc_blanks lines
 # HELP scc_blanks Number of blank lines.
 # TYPE scc_complexity count
-# UNIT scc_complexity lines
 # HELP scc_complexity Code complexity.
 # TYPE scc_bytes count
 # UNIT scc_bytes bytes
 # HELP scc_bytes Size in bytes.
-scc_lines{language="Go", file="C:\\bbbb.go"} 1000
-scc_code{language="Go", file="C:\\bbbb.go"} 1000
-scc_comments{language="Go", file="C:\\bbbb.go"} 1000
-scc_blanks{language="Go", file="C:\\bbbb.go"} 1000
-scc_complexity{language="Go", file="C:\\bbbb.go"} 1000
-scc_bytes{language="Go", file="C:\\bbbb.go"} 1000
+scc_lines{language="Go",file="C:\\bbbb.go"} 1000
+scc_code{language="Go",file="C:\\bbbb.go"} 1000
+scc_comments{language="Go",file="C:\\bbbb.go"} 1000
+scc_blanks{language="Go",file="C:\\bbbb.go"} 1000
+scc_complexity{language="Go",file="C:\\bbbb.go"} 1000
+scc_bytes{language="Go",file="C:\\bbbb.go"} 1000
 `
 
 	if res != expectedResult {


### PR DESCRIPTION
The current output is valid for Prometheus, but not the derived OpenMetrics format:
- Spaces between comma-separated labels are not permitted
- The exposition must end with a `# EOF` line
- UNIT must be a suffix of the metric name, i.e. `scc_code` cannot have the unit `lines`

Additionally:
- Complexity is not measured in 'lines'

For reference, see:
https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md

I chose to remove the invalid `UNIT`s instead of renaming them to 1) not break people's monitoring and dashboards and 2) keep things consistent with the internal names, and names used in other output formats.

Ref #307, cc @jan-guenter