### PR TITLE
Patch csv-stream format

### DIFF
--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -467,11 +468,17 @@ func toOpenMetricsFiles(input chan *FileJob) string {
 func toCSVStream(input chan *FileJob) string {
 	fmt.Println("Language,Location,Filename,Lines,Code,Comments,Blanks,Complexity,Bytes")
 
+	var quoteRegex = regexp.MustCompile("\"")
+
 	for result := range input {
+		// Escape quotes in location and filename then surround with quotes.
+		var location = "\"" + quoteRegex.ReplaceAllString(result.Location, "\"\"") + "\""
+		var filename = "\"" + quoteRegex.ReplaceAllString(result.Filename, "\"\"") + "\""
+
 		fmt.Println(fmt.Sprintf("%s,%s,%s,%s,%s,%s,%s,%s,%s",
 			result.Language,
-			result.Location,
-			result.Filename,
+			location,
+			filename,
 			fmt.Sprint(result.Lines),
 			fmt.Sprint(result.Code),
 			fmt.Sprint(result.Comment),


### PR DESCRIPTION
Updated the csv-stream format to escape double quotes in the location and filename fields, then surround each field with double quotes.

This patches https://github.com/boyter/scc/issues/371

This submitted code is licensed under MIT AND The Unlicense.