### PR TITLE
README: remove duplicated noun in "it `scc`"

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,14 +491,14 @@ identify the most complex file inside a project based on the complexity estimate
 
 JSON produces JSON output. Mostly designed to allow `scc` to feed into other programs.
 
-Note that this format will give you the byte size of every file it `scc` reads allowing you to get a breakdown of the
+Note that this format will give you the byte size of every file `scc` reads allowing you to get a breakdown of the
 number of bytes processed.
 
 #### CSV
 
 CSV as an option is good for importing into a spreadsheet for analysis. 
 
-Note that this format will give you the byte size of every file it `scc` reads allowing you to get a breakdown of the
+Note that this format will give you the byte size of every file `scc` reads allowing you to get a breakdown of the
 number of bytes processed. Also note that CSV respects `--by-file` and as such will return a summary by default.
 
 #### CSV-Stream
@@ -575,7 +575,7 @@ The markup is designed to allow your own custom styles to be applied. An example
 Note that the HTML options follow the command line options, so you can use `scc --by-file -f html` to produce a report with every
 file and not just the summary.
 
-Note that this format if it has the `--by-file` option will give you the byte size of every file it `scc` reads allowing you to get a breakdown of the
+Note that this format if it has the `--by-file` option will give you the byte size of every file `scc` reads allowing you to get a breakdown of the
 number of bytes processed.
 
 #### SQL and SQL-Insert


### PR DESCRIPTION
Now only uses `scc`.