### PR TITLE
Fix incorrect string escaping

### DIFF
--- a/examples/issue345/filename.cc
+++ b/examples/issue345/filename.cc
@@ -1,0 +1,4 @@
+bool MyFunction() {
+    func("double\\escaped\\string\\");
+    // comment
+}

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -130,8 +130,27 @@ func stringState(fileJob *FileJob, index int, endPoint int, stringTrie *Trie, en
 			return i, currentState
 		}
 
-		// If we are in a literal string we want to ignore the \ check OR we aren't checking for special ones
-		if ignoreEscape || fileJob.Content[i-1] != '\\' {
+		is_escaped := false
+		// if there is an escape symbol before us, investigate
+		if fileJob.Content[i-1] == '\\' {
+			num_escapes := 0
+			for j := i - 1; j > 0; j -= 1 {
+				if fileJob.Content[j] == '\\' {
+					num_escapes += 1
+				} else {
+					break
+				}
+			}
+
+			// if number of escapes is even, all escapes are themselves escaped
+			// otherwise the last escape does escape current string terminator
+			if num_escapes%2 != 0 {
+				is_escaped = true
+			}
+		}
+
+		// If we are in a literal string we want to ignore escapes OR we aren't checking for special ones
+		if ignoreEscape || !is_escaped {
 			if checkForMatchSingle(fileJob.Content[i], index, endPoint, endString, fileJob) {
 				return i, SCode
 			}

--- a/test-all.sh
+++ b/test-all.sh
@@ -909,6 +909,19 @@ do
     fi
 done
 
+# Issue345 (https://github.com/boyter/scc/issues/345)
+a=$(./scc "examples/issue345/" -f csv | sed -n '2 p')
+b="C++,4,3,1,0,0,76"
+if [ "$a" == "$b" ]; then
+    echo -e "{GREEN}PASSED string termination check"
+else
+    echo -e "$a"
+    echo -e "${RED}======================================================="
+    echo -e "FAILED Should terminate the string properly"
+    echo -e "=======================================================${NC}"
+    exit
+fi
+
 
 # Extra case for longer languages that are normally truncated
 for i in 'CloudFormation (YAM' 'CloudFormation (JSO'


### PR DESCRIPTION
Previously, only one char got checked for escapes when parsing strings. This meant that strings such as "\\" never got terminated, leading to incorrect parsing.

This commit adds a check which calculates the number of escapes pre-string ending to determine wherever the last escape is itself escaped or not.

This was prompted by issue #345, I also added a test case for it.

One important note is that I am unsure how much that impacts performance.  The for loop is only accessed if the string has an escape before it, so it should be a fairly rare path.