### PR TITLE
Fix CI: go.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go
       uses: actions/setup-go@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,9 +14,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.17
+        go-version-file: './go.mod'
 
     - name: Build
       run: go build -v ./...

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ jobs:
     name: A job to count the lines of code.
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get the lines of code.
         id: scc
         uses: iryanbell/scc-docker-action@v1.0.2


### PR DESCRIPTION
- <https://github.com/rivo/uniseg> requires Go 1.18 for generics; use Go version found in `go.mod` for CI instead of Go 1.17.
- `actions/checkout@v2` uses Node 12 which is deprecated by GitHub; upgrade to `actions/checkout@v3`

---

This patch is licensed under MIT License and The Unlicense.