### PR TITLE
do not add a '~' when filename is not truncated

### DIFF
--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -931,7 +931,7 @@ func unicodeAwareTrim(tmp string, size int) string {
 	// iterate all the runes so we can cut off correctly and get the correct length
 	r := []rune(tmp)
 
-	if len(r) >= size {
+	if len(r) > size {
 		for runewidth.StringWidth(tmp) > size {
 			// remove character one at a time till we get the length we want
 			tmp = string([]rune(tmp)[1:])

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -1392,6 +1392,14 @@ func TestUnicodeAwareTrimAscii(t *testing.T) {
 	}
 }
 
+func TestUnicodeAwareTrimExactSizeAscii(t *testing.T) {
+	tmp := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.md"
+	res := unicodeAwareTrim(tmp, len(tmp))
+	if res != tmp {
+		t.Errorf("expected %s got %s", tmp, res)
+	}
+}
+
 func TestUnicodeAwareTrimUnicode(t *testing.T) {
 	tmp := "中文中文中文中文中文中文中文中文中文中文中文中文中文中文中文中文.md"
 	res := unicodeAwareTrim(tmp, shortFormatFileTruncate)


### PR DESCRIPTION
This fixes an off-by-one when the filename length exactly matches our size limit. As an example, today if the filename size limit is one character and the filename is named "a", it will be incorrectly formatted as "~a" despite no truncation occuring.