### PR TITLE
Avoid allocations with `(*regexp.Regexp).MatchString`

### DIFF
--- a/processor/file.go
+++ b/processor/file.go
@@ -158,7 +158,7 @@ DIRENTS:
 		}
 
 		for _, exclude := range dw.excludes {
-			if exclude.Match([]byte(name)) || exclude.Match([]byte(path)) {
+			if exclude.MatchString(name) || exclude.MatchString(path) {
 				if Verbose {
 					printWarn("skipping file/directory due to match exclude: " + name)
 				}


### PR DESCRIPTION
We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` when matching string to avoid unnecessary `[]byte` conversions and reduce allocations. A one-line change for free performance improvement.

Example benchmark:

```go
var excludeRegex = regexp.MustCompile("vendor")

func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := excludeRegex.Match([]byte("vendor/pkg/main.go")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := excludeRegex.MatchString("vendor/pkg/main.go"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/boyter/scc/v3/processor
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 4123592	       274.9 ns/op	      24 B/op	       1 allocs/op
BenchmarkMatchString-16    	 7006401	       145.1 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/boyter/scc/v3/processor	2.637s
```