### PR TITLE
Fix docker image build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,8 +6,8 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: '36 1 * * *'
+  #schedule:
+  #  - cron: '36 1 * * *'
   push:
     branches: [ "master" ]
     # Publish semver tags as releases.
@@ -76,11 +76,10 @@ jobs:
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ GOARCH=amd64 \
 CGO_ENABLED=0
 
 ARG VERSION=v3.2.0
-RUN git clone --branch $VERSION --depth 1 https://github.com/boyter/scc
-WORKDIR /go/scc
-RUN go build -ldflags="-s -w"
+COPY . /scc
+WORKDIR /scc
+RUN go build -ldflags="-s -w" -o /bin/scc
 
 FROM alpine:3.19
-COPY --from=scc-get /go/scc/scc /bin/
-ENTRYPOINT ["scc"]
+COPY --from=scc-get /bin/scc /bin/scc
+CMD ["/bin/scc"]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ Or, if you prefer to build from source, you can use the ports tree
 
 `$ cd /usr/ports/devel/scc && make install clean`
 
+### Run in Docker
+
+Go to the directory you want to run scc from.
+
+Run the command below to run the latest release of scc on your current working directory:
+
+```
+docker run --rm -it -v "$PWD:/pwd"  ghcr.io/lhoupert/scc:master scc /pwd
+```
+
 #### Manual
 
 Binaries for Windows, GNU/Linux and macOS for both i386 and x86_64 machines are available from the [releases](https://github.com/boyter/scc/releases) page.


### PR DESCRIPTION
Hi,
Sorry I realised my previous pull request was wrong as the dockerfile was not relevant for a fork. 
I did some changes and tested, it seems to be working fine on my fork: https://github.com/lhoupert/scc/pkgs/container/scc 

You can test running the v0.0.2 of docker image generated on my fork with the command below :

```
docker run --rm -it -v "$PWD:/pwd"  ghcr.io/lhoupert/scc:v0.0.2 scc /pwd
```

This should fix the github action. Each new release of scc should also create a tagged docker image