### PR TITLE
Add lesser-known ILPROJ extension to MSBUILD

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -4544,6 +4544,7 @@
       "vcproj",
       "vcxproj",
       "vcxproj.filters",
+      "ilproj",
       "myapp",
       "props",
       "rdlc",


### PR DESCRIPTION
Many ILPROJ (Intermediate Language Project) files occur, for example, in https://github.com/dotnet/runtime. These are rather like CSPROJ files, and it seems they should be included in the MSBuild category. For some further discussion of ILPROJ, see https://github.com/dotnet/sdk/issues/16690.