### PR TITLE
Add `pnpm-lock.yaml` to default exclude file list

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Flags:
       --eaf float                    the effort adjustment factor derived from the cost drivers (1.0 if rated nominal) (default 1)
       --exclude-dir strings          directories to exclude (default [.git,.hg,.svn])
   -x, --exclude-ext strings          ignore file extensions (overrides include-ext) [comma separated list: e.g. go,java,js]
-  -n, --exclude-file strings         ignore files with matching names (default [package-lock.json,Cargo.lock,yarn.lock,pubspec.lock,Podfile.lock])
+  -n, --exclude-file strings         ignore files with matching names (default [package-lock.json,Cargo.lock,yarn.lock,pubspec.lock,Podfile.lock,pnpm-lock.yaml])
       --file-gc-count int            number of files to parse before turning the GC on (default 10000)
   -f, --format string                set output format [tabular, wide, json, json2, csv, csv-stream, cloc-yaml, html, html-table, sql, sql-insert, openmetrics] (default "tabular")
       --format-multi string          have multiple format output overriding --format [e.g. tabular:stdout,csv:file.csv,json:file.json]

--- a/main.go
+++ b/main.go
@@ -159,7 +159,7 @@ func main() {
 		&processor.ExcludeFilename,
 		"exclude-file",
 		"n",
-		[]string{"package-lock.json", "Cargo.lock", "yarn.lock", "pubspec.lock", "Podfile.lock"},
+		[]string{"package-lock.json", "Cargo.lock", "yarn.lock", "pubspec.lock", "Podfile.lock", "pnpm-lock.yaml"},
 		"ignore files with matching names",
 	)
 	flags.BoolVarP(


### PR DESCRIPTION
`pnpm-lock.yaml` is the file just like `package-lock.json` or `yarn.lock`