### PR TITLE
Add --no-hborder

### DIFF
--- a/main.go
+++ b/main.go
@@ -211,6 +211,12 @@ func main() {
 		false,
 		"remove size calculation output",
 	)
+	flags.BoolVar(
+		&processor.HBorder,
+		"no-hborder",
+		false,
+		"remove horizontal borders between sections",
+	)
 	flags.StringVar(
 		&processor.SizeUnit,
 		"size-unit",

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -142,6 +142,10 @@ type languageReportEnd struct {
 }
 
 func getTabularShortBreak() string {
+	if HBorder {
+		return ""
+	}
+
 	if Ci {
 		return tabularShortBreakCi
 	}
@@ -150,6 +154,10 @@ func getTabularShortBreak() string {
 }
 
 func getTabularWideBreak() string {
+	if HBorder {
+		return ""
+	}
+
 	if Ci {
 		return tabularWideBreakCi
 	}

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -3,9 +3,10 @@
 package processor
 
 import (
-	"github.com/mattn/go-runewidth"
 	"strings"
 	"testing"
+
+	"github.com/mattn/go-runewidth"
 )
 
 func TestPrintTrace(t *testing.T) {
@@ -1316,21 +1317,36 @@ func TestGetTabularShortBreak(t *testing.T) {
 }
 
 func TestGetTabularWideBreak(t *testing.T) {
-	Ci = false
-	r := getTabularWideBreak()
-
-	if !strings.Contains(r, "─") {
-		t.Errorf("Expected to have box line")
+	{
+		Ci, HBorder = false, false
+		r := getTabularWideBreak()
+		if !strings.Contains(r, "─") {
+			t.Errorf("Expected to have box line")
+		}
+	}
+	{
+		Ci, HBorder = false, true
+		r := getTabularWideBreak()
+		if strings.Contains(r, "─") {
+			t.Errorf("Didn't expect to have box line")
+		}
+	}
+	{
+		Ci, HBorder = true, false
+		r := getTabularWideBreak()
+		if !strings.Contains(r, "-") {
+			t.Errorf("Expected to have hyphen")
+		}
+	}
+	{
+		Ci, HBorder = true, true
+		r := getTabularWideBreak()
+		if strings.Contains(r, "-") {
+			t.Errorf("Didn't expect to have hyphen")
+		}
 	}
 
-	Ci = true
-	r = getTabularWideBreak()
-
-	if !strings.Contains(r, "-") {
-		t.Errorf("Expected to have hyphen")
-	}
-
-	Ci = false
+	Ci, HBorder = false, false
 }
 
 func TestToHTML(t *testing.T) {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -87,6 +87,9 @@ var CocomoProjectType = "organic"
 // Size toggles the Size calculation
 var Size = false
 
+// Draw horizontal borders between sections.
+var HBorder = false
+
 // SizeUnit determines what size calculation is used for megabytes
 var SizeUnit = "si"
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -659,7 +659,7 @@ func Process() {
 
 	result := fileSummarize(fileSummaryJobQueue)
 	if FileOutput == "" {
-		fmt.Println(result)
+		fmt.Print(result)
 	} else {
 		_ = os.WriteFile(FileOutput, []byte(result), 0644)
 		fmt.Println("results written to " + FileOutput)


### PR DESCRIPTION
This removes the horizontal border lines, making for more compact output.

For example:

	% scc --min-gen --no-complexity --no-cocomo --no-size
	───────────────────────────────────────────────────────────────────────────────
	Language                     Files       Lines     Blanks    Comments      Code
	───────────────────────────────────────────────────────────────────────────────
	Go                              10        1374        114         199      1061
	License                          1          20          4           0        16
	Markdown                         1          94         23           0        71
	YAML                             1           1          0           0         1
	───────────────────────────────────────────────────────────────────────────────
	Total                           13        1489        141         199      1149
	───────────────────────────────────────────────────────────────────────────────

	% scc --min-gen --no-complexity --no-cocomo --no-size --no-hborder
	Language                     Files       Lines     Blanks    Comments      Code
	Go                              10        1374        114         199      1061
	License                          1          20          4           0        16
	Markdown                         1          94         23           0        71
	YAML                             1           1          0           0         1
	Total                           13        1489        141         199      1149

Removing those four lines makes a relatively large difference.

I named it "hborder" so that it won't be problematic with any potential future vertical borders. Maybe at some point an option for something like this will be added:

	Language │ Files │  Lines │ Blanks │ Comments  │ Code
	─────────┼───────┼────────┼────────┼───────────┼─────
	Go       │    10 │   1374 │    114 │      199  │ 1061
	License  │     1 │     20 │      4 │        0  │   16
	Markdown │     1 │     94 │     23 │        0  │   71
	YAML     │     1 │      1 │      0 │        0  │    1
	─────────┼───────┼────────┼────────┼───────────┼─────
	Total    │    13 │   1489 │    141 │      199  │ 1149

Or something along those lines.