### PR TITLE
Use strings.EqualFold in case-insensitive comparisons

### DIFF
--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -784,27 +784,27 @@ func fileSummarize(input chan *FileJob) string {
 	}
 
 	switch {
-	case More || strings.ToLower(Format) == "wide":
+	case More || strings.EqualFold(Format, "wide"):
 		return fileSummarizeLong(input)
-	case strings.ToLower(Format) == "json":
+	case strings.EqualFold(Format, "json"):
 		return toJSON(input)
-	case strings.ToLower(Format) == "json2":
+	case strings.EqualFold(Format, "json2"):
 		return toJSON2(input)
-	case strings.ToLower(Format) == "cloc-yaml" || strings.ToLower(Format) == "cloc-yml":
+	case strings.EqualFold(Format, "cloc-yaml") || strings.EqualFold(Format, "cloc-yml"):
 		return toClocYAML(input)
-	case strings.ToLower(Format) == "csv":
+	case strings.EqualFold(Format, "csv"):
 		return toCSV(input)
-	case strings.ToLower(Format) == "csv-stream":
+	case strings.EqualFold(Format, "csv-stream"):
 		return toCSVStream(input)
-	case strings.ToLower(Format) == "html":
+	case strings.EqualFold(Format, "html"):
 		return toHtml(input)
-	case strings.ToLower(Format) == "html-table":
+	case strings.EqualFold(Format, "html-table"):
 		return toHtmlTable(input)
-	case strings.ToLower(Format) == "sql":
+	case strings.EqualFold(Format, "sql"):
 		return toSql(input)
-	case strings.ToLower(Format) == "sql-insert":
+	case strings.EqualFold(Format, "sql-insert"):
 		return toSqlInsert(input)
-	case strings.ToLower(Format) == "openmetrics":
+	case strings.EqualFold(Format, "openmetrics"):
 		return toOpenMetrics(input)
 	}
 
@@ -1413,7 +1413,7 @@ func calculateSize(sumBytes int64, str *strings.Builder) {
 		SizeUnit = "SI"
 	}
 
-	if strings.ToLower(SizeUnit) != "xkcd-imaginary" {
+	if !strings.EqualFold(SizeUnit, "xkcd-imaginary") {
 		str.WriteString(fmt.Sprintf("Processed %d bytes, %.3f megabytes (%s)\n", sumBytes, size, strings.ToUpper(SizeUnit)))
 	}
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -332,7 +332,7 @@ func setupCountAs() {
 			// See if we can identify based on language name which is the most
 			// reliable as the name should be unique
 			for name := range languageDatabase {
-				if strings.ToLower(name) == strings.ToLower(t[1]) {
+				if strings.EqualFold(name, t[1]) {
 					ExtensionToLanguage[strings.ToLower(t[0])] = []string{name}
 					identified = true
 					if Debug {


### PR DESCRIPTION
`strings.EqualFold` is simpler and much faster than `strings.ToLower`.