### PR TITLE
Enhance scripts/include.go and fix warnings

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>30</th>
-		<th>9515</th>
-		<th>1460</th>
-		<th>456</th>
-		<th>7599</th>
-		<th>1516</th>
-		<th>254099</th>
-		<th>4050</th>
+		<th>9627</th>
+		<th>1481</th>
+		<th>468</th>
+		<th>7678</th>
+		<th>1536</th>
+		<th>256617</th>
+		<th>4092</th>
 	</tr><tr>
 		<td>processor/formatters.go</td>
 		<td></td>
@@ -93,13 +93,13 @@
 	</tr><tr>
 		<td>cmd/badges/main.go</td>
 		<td></td>
-		<td>342</td>
+		<td>345</td>
 		<td>59</td>
 		<td>14</td>
-		<td>269</td>
-		<td>47</td>
-	    <td>7991</td>
-		<td>202</td>
+		<td>272</td>
+		<td>50</td>
+	    <td>8129</td>
+		<td>204</td>
 	</tr><tr>
 		<td>processor/workers_tokei_test.go</td>
 		<td></td>
@@ -113,13 +113,13 @@
 	</tr><tr>
 		<td>processor/detector.go</td>
 		<td></td>
-		<td>236</td>
+		<td>237</td>
 		<td>44</td>
 		<td>33</td>
-		<td>159</td>
+		<td>160</td>
 		<td>57</td>
-	    <td>6232</td>
-		<td>151</td>
+	    <td>6243</td>
+		<td>152</td>
 	</tr><tr>
 		<td>processor/file_test.go</td>
 		<td></td>
@@ -161,6 +161,16 @@
 	    <td>3766</td>
 		<td>99</td>
 	</tr><tr>
+		<td>cmd/badges/simplecache.go</td>
+		<td></td>
+		<td>161</td>
+		<td>28</td>
+		<td>13</td>
+		<td>120</td>
+		<td>20</td>
+	    <td>3070</td>
+		<td>94</td>
+	</tr><tr>
 		<td>processor/processor_test.go</td>
 		<td></td>
 		<td>151</td>
@@ -181,15 +191,15 @@
 	    <td>1911</td>
 		<td>60</td>
 	</tr><tr>
-		<td>cmd/badges/simplecache.go</td>
+		<td>cmd/badges/simplecache_test.go</td>
 		<td></td>
-		<td>109</td>
+		<td>102</td>
+		<td>21</td>
+		<td>3</td>
+		<td>78</td>
 		<td>17</td>
-		<td>4</td>
-		<td>88</td>
-		<td>14</td>
-	    <td>1931</td>
-		<td>75</td>
+	    <td>2024</td>
+		<td>52</td>
 	</tr><tr>
 		<td>processor/structs_test.go</td>
 		<td></td>
@@ -203,13 +213,13 @@
 	</tr><tr>
 		<td>scripts/include.go</td>
 		<td></td>
-		<td>76</td>
-		<td>15</td>
-		<td>8</td>
-		<td>53</td>
+		<td>82</td>
 		<td>16</td>
-	    <td>1796</td>
-		<td>56</td>
+		<td>8</td>
+		<td>58</td>
+		<td>19</td>
+	    <td>2043</td>
+		<td>60</td>
 	</tr><tr>
 		<td>processor/processor_unix.go</td>
 		<td></td>
@@ -231,16 +241,6 @@
 	    <td>1316</td>
 		<td>37</td>
 	</tr><tr>
-		<td>cmd/badges/simplecache_test.go</td>
-		<td></td>
-		<td>52</td>
-		<td>12</td>
-		<td>0</td>
-		<td>40</td>
-		<td>9</td>
-	    <td>1041</td>
-		<td>30</td>
-	</tr><tr>
 		<td>processor/cocomo.go</td>
 		<td></td>
 		<td>43</td>
@@ -251,16 +251,6 @@
 	    <td>2209</td>
 		<td>35</td>
 	</tr><tr>
-		<td>processor/bloom.go</td>
-		<td></td>
-		<td>37</td>
-		<td>7</td>
-		<td>12</td>
-		<td>18</td>
-		<td>2</td>
-	    <td>1062</td>
-		<td>29</td>
-	</tr><tr>
 		<td>processor/cocomo_test.go</td>
 		<td></td>
 		<td>37</td>
@@ -270,6 +260,16 @@
 		<td>6</td>
 	    <td>686</td>
 		<td>23</td>
+	</tr><tr>
+		<td>processor/bloom.go</td>
+		<td></td>
+		<td>37</td>
+		<td>7</td>
+		<td>12</td>
+		<td>18</td>
+		<td>2</td>
+	    <td>1062</td>
+		<td>29</td>
 	</tr><tr>
 		<td>processor/helpers_test.go</td>
 		<td></td>
@@ -324,15 +324,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>30</th>
-		<th>9515</th>
-		<th>1460</th>
-		<th>456</th>
-		<th>7599</th>
-		<th>1516</th>
-    	<th>254099</th>
-		<th>4050</th>
+		<th>9627</th>
+		<th>1481</th>
+		<th>468</th>
+		<th>7678</th>
+		<th>1536</th>
+    	<th>256617</th>
+		<th>4092</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $227,190<br>Estimated Schedule Effort (organic) 7.83 months<br>Estimated People Required (organic) 2.58<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $229,670<br>Estimated Schedule Effort (organic) 7.86 months<br>Estimated People Required (organic) 2.59<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/cmd/badges/main.go
+++ b/cmd/badges/main.go
@@ -67,7 +67,10 @@ func main() {
 
 	addr := ":8080"
 	log.Info().Str(uniqueCode, "1876ce1e").Str("addr", addr).Msg("serving")
-	http.ListenAndServe(addr, nil).Error()
+	if err := http.ListenAndServe(addr, nil); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Error().Str(uniqueCode, "c28556e8").Err(err).Send()
+		os.Exit(1)
+	}
 }
 
 func calculate(category string, wage int, res []processor.LanguageSummary) (string, int64) {

--- a/processor/detector.go
+++ b/processor/detector.go
@@ -89,6 +89,7 @@ func scanForSheBang(content []byte) (string, error) {
 	candidate1 := ""
 	candidate2 := ""
 
+loop:
 	for i := range content {
 		switch state {
 		case 0: // Deals with whitespace after #! and before first /
@@ -128,7 +129,7 @@ func scanForSheBang(content []byte) (string, error) {
 				state = 4
 			}
 		case 4:
-			break
+			break loop
 		}
 	}
 

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -843,7 +843,7 @@ func fileSummarizeMulti(input chan *FileJob) string {
 			}
 			close(i)
 
-			var val = ""
+			var val string
 
 			switch strings.ToLower(t[0]) {
 			case "tabular":
@@ -861,8 +861,8 @@ func fileSummarizeMulti(input chan *FileJob) string {
 			case "csv":
 				val = toCSV(i)
 			case "csv-stream":
-				val = toCSVStream(i)
 				// special case where we want to ignore writing to stdout to disk as it's already done
+				_ = toCSVStream(i)
 				continue
 			case "html":
 				val = toHtml(i)


### PR DESCRIPTION
Write tmp data to a buffer rather than a temp file. This is faster and robuster.

Fix some golangci-lint warnings.

Fix a miss use of break, a break in a switch only stop the switch statment, to stop the outer for-loop we need a label.