### PR TITLE
Tell GitHub that `.sccignore` is an ignore list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.sccignore linguist-language=Ignore-List


### PR DESCRIPTION
This is a super-nitpicky PR, because I like to see syntax highlighting when I look at a file :sweat_smile: I think you're already familiar with linguist, but just to describe what this PR does:

- Applies Ignore List syntax highlighting to `.sccignore`
- If for whatever reason you decided to include Ignore List stats in the GitHub language bar, `.sccignore` would be counted to that.