### PR TITLE
Make winget install more specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Or if you are using [Chocolatey](https://chocolatey.org/) on Windows
 
 Or if you are using [WinGet](https://github.com/microsoft/winget-cli) on Windows
 
-`winget install benboyter.scc`
+`winget install --id benboyter.scc --source winget`
 
 #### FreeBSD
 


### PR DESCRIPTION
I'm basically just copying good instructions that I've seen in other projects. What this does is add:

- `--id` option that ensures that `benboyter.scc` is the ID. Without this `benboyter.scc` is getting passed as a query instead of as a unique ID. This could potentially cause a similarly named package to get installed.
- `--source` option to specify that the `winget` repository should be used.

Personally, I *always* use the `--id` option with `winget`.