### PR TITLE
Catch any `os.Stat` error

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -581,8 +581,8 @@ func Process() {
 		fpath := filepath.Clean(f)
 
 		s, err := os.Stat(fpath)
-		if os.IsNotExist(err) {
-			fmt.Println("file or directory does not exist: " + fpath)
+		if err != nil {
+			fmt.Println("file or directory could not be read: " + fpath)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
tl;dr I discovered some weird Windows behavior where an invalid path causes `scc.exe` to panic. Surprisingly, the error is *not* a "does not exist" error. After some thought it seemed better to exit on *any* non-nil error.

In PowerShell, I tried to run `scc.exe *.go`, and to my surprise I got a panic. PowerShell did not expand the glob -- that's not scc's fault, although potentially [glob expansion can be added as a feature](https://pkg.go.dev/path/filepath#Glob) if that's reasonable. But the issue is that, on Windows, apparently this does *not* raise a "does not exist" error. So `os.Stat()` returns `nil, err` where `err` is *not* `nil`. So the call to `s.IsDir()` raises a nil pointer dereference error.

I did some playing around using the code below:

```go
package main

import "os"
import "path/filepath"
import "fmt"
import "io/fs"

func main() {
	arg := "."
	if len(os.Args) > 1 {
		arg = os.Args[1]
	}
	arg = filepath.Clean(arg)
	fmt.Println("statting", arg)
	s, err := os.Stat(arg)
	fmt.Printf("s = %v, err = %v\n", s, err)

	checks := []struct {
		name  string
		check func(err error) bool
	}{
		{
			name:  "IsNotExist",
			check: os.IsNotExist,
		},
		{
			name:  "IsExist",
			check: os.IsExist,
		},
		{
			name:  "IsPermission",
			check: os.IsPermission,
		},
	}

	for _, c := range checks {
		fmt.Println(c.name, c.check(err))
	}

	if err, ok := err.(*fs.PathError); ok {
		fmt.Println("err.Op =", err.Op)
	}
}
```

And here's the result of `go run .\main.go "?"`:

```console
statting ?
s = <nil>, err = CreateFile ?: The filename, directory name, or volume label syntax is incorrect.
IsNotExist false
IsExist false
IsPermission false
err.Op = CreateFile
```

Perhaps unexpectedly, `filepath.Clean` does *not* clean the invalid character `?`. Also, `CreateFile` is *not* the op that I would expect :thinking:

At first I wanted to narrow down to exactly the error type, but then I figured that it should be fine to treat any `os.Stat` error the same, especially with more unusual errors like these.