### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,13 @@
     "name": "Go",
     "image": "mcr.microsoft.com/devcontainers/go:1.22",
     "customizations": {
+        "codespaces": {
+            "openFiles": [
+                "CODE_OF_CONDUCT.md",
+                "CONTRIBUTING.md",
+                "README.md"
+            ]
+        },
         "vscode": {
             "extensions": ["golang.go"],
             "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+    "name": "Go",
+    "image": "mcr.microsoft.com/devcontainers/go:1.22",
+    "customizations": {
+        "vscode": {
+            "extensions": ["golang.go"],
+            "settings": {
+                "go.gopath": "/go"
+            }
+        }
+    },
+    "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,8 @@
             "openFiles": [
                 "CODE_OF_CONDUCT.md",
                 "CONTRIBUTING.md",
-                "README.md"
+                "README.md",
+                "languages.json"
             ]
         },
         "vscode": {


### PR DESCRIPTION
For various reasons, I like to use GitHub Codespaces sometimes.

I can go into some more details if necessary, but here are the highlights:

- Contributors can use a GitHub Codespace (container on the cloud) and code with VS Code running in the browser
- Contributors can create a development container locally if they have Docker and an editor that supports dev containers

There are a few ways to use a codespace, but the easiest is probably going to be to just press <kbd>,</kbd> while viewing your repository on github.com.

Even without this config one can open a codespace with a default image, which I think has Go installed, but this can be used to ensure the proper version is installed and also guide users to certain files (the `openFiles` option).