### PR TITLE
refactor: using standard libraries to do file operations

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,12 +13,12 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>27</th>
-		<th>9513</th>
-		<th>1458</th>
+		<th>9495</th>
+		<th>1452</th>
 		<th>444</th>
-		<th>7611</th>
-		<th>1501</th>
-		<th>252876</th>
+		<th>7599</th>
+		<th>1502</th>
+		<th>252699</th>
 		<th>4061</th>
 	</tr><tr>
 		<td>processor/workers_test.go</td>
@@ -67,9 +67,9 @@
 		<td>142</td>
 		<td>104</td>
 		<td>430</td>
-		<td>93</td>
-	    <td>19515</td>
-		<td>441</td>
+		<td>94</td>
+	    <td>19510</td>
+		<td>440</td>
 	</tr><tr>
 		<td>main.go</td>
 		<td></td>
@@ -93,13 +93,13 @@
 	</tr><tr>
 		<td>cmd/badges/main.go</td>
 		<td></td>
-		<td>345</td>
-		<td>59</td>
+		<td>327</td>
+		<td>53</td>
 		<td>14</td>
-		<td>272</td>
+		<td>260</td>
 		<td>50</td>
-	    <td>8129</td>
-		<td>204</td>
+	    <td>7957</td>
+		<td>206</td>
 	</tr><tr>
 		<td>processor/workers_tokei_test.go</td>
 		<td></td>
@@ -294,15 +294,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>27</th>
-		<th>9513</th>
-		<th>1458</th>
+		<th>9495</th>
+		<th>1452</th>
 		<th>444</th>
-		<th>7611</th>
-		<th>1501</th>
-    	<th>252876</th>
+		<th>7599</th>
+		<th>1502</th>
+    	<th>252699</th>
 		<th>4061</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $227,566<br>Estimated Schedule Effort (organic) 7.84 months<br>Estimated People Required (organic) 2.58<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $227,190<br>Estimated Schedule Effort (organic) 7.83 months<br>Estimated People Required (organic) 2.58<br></th>
 	</tr></tfoot>
 	</table></body></html>


### PR DESCRIPTION
Using standard libraries to get temp path and to do file operations.

This makes the program more simple and safer because standard libraries clean the path and no need to use outside commands.

It also makes the code more portable since not all systems use '/tmp' as its tempfile path (other places for example, '/data/local/tmp'). Many mordern Linux distros also support setting the env varibale '$TMPDIR' to change a program's tempfile path. So using the standard library's getTempDir function is a better idea, it's done all the works for us.