### PR TITLE
Support `licen(c|s)e-apache`

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -3504,6 +3504,8 @@
       "copying3",
       "unlicense",
       "unlicence",
+      "license-apache",
+      "licence-apache",
       "license-mit",
       "licence-mit",
       "copyright"


### PR DESCRIPTION
It's a pretty common filename: https://github.com/search?q=path%3A%2F%28%5E%7C%5C%2F%29LICEN%28S%7CC%29E-APACHE%24%2F&type=code

You'll often see it in Rust projects, which are often MIT/Apache-2.0 dual-licensed.