### PR TITLE
Simplify and clean up the code

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>27</th>
-		<th>9629</th>
-		<th>1462</th>
-		<th>449</th>
-		<th>7718</th>
-		<th>1513</th>
-		<th>256852</th>
-		<th>4141</th>
+		<th>9577</th>
+		<th>1461</th>
+		<th>447</th>
+		<th>7669</th>
+		<th>1413</th>
+		<th>254907</th>
+		<th>4126</th>
 	</tr><tr>
 		<td>processor/workers_test.go</td>
 		<td></td>
@@ -33,13 +33,13 @@
 	</tr><tr>
 		<td>processor/formatters.go</td>
 		<td></td>
-		<td>1561</td>
-		<td>209</td>
-		<td>41</td>
-		<td>1311</td>
-		<td>263</td>
-	    <td>46071</td>
-		<td>792</td>
+		<td>1517</td>
+		<td>208</td>
+		<td>39</td>
+		<td>1270</td>
+		<td>163</td>
+	    <td>44230</td>
+		<td>784</td>
 	</tr><tr>
 		<td>processor/formatters_test.go</td>
 		<td></td>
@@ -93,13 +93,13 @@
 	</tr><tr>
 		<td>cmd/badges/main.go</td>
 		<td></td>
-		<td>382</td>
+		<td>374</td>
 		<td>60</td>
 		<td>17</td>
-		<td>305</td>
+		<td>297</td>
 		<td>59</td>
-	    <td>9675</td>
-		<td>243</td>
+	    <td>9571</td>
+		<td>239</td>
 	</tr><tr>
 		<td>processor/workers_tokei_test.go</td>
 		<td></td>
@@ -131,16 +131,6 @@
 	    <td>4585</td>
 		<td>97</td>
 	</tr><tr>
-		<td>processor/structs.go</td>
-		<td></td>
-		<td>199</td>
-		<td>21</td>
-		<td>18</td>
-		<td>160</td>
-		<td>17</td>
-	    <td>5883</td>
-		<td>139</td>
-	</tr><tr>
 		<td>cmd/badges/main_test.go</td>
 		<td></td>
 		<td>199</td>
@@ -150,6 +140,16 @@
 		<td>10</td>
 	    <td>4088</td>
 		<td>106</td>
+	</tr><tr>
+		<td>processor/structs.go</td>
+		<td></td>
+		<td>199</td>
+		<td>21</td>
+		<td>18</td>
+		<td>160</td>
+		<td>17</td>
+	    <td>5883</td>
+		<td>139</td>
 	</tr><tr>
 		<td>processor/workers_regression_test.go</td>
 		<td></td>
@@ -294,15 +294,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>27</th>
-		<th>9629</th>
-		<th>1462</th>
-		<th>449</th>
-		<th>7718</th>
-		<th>1513</th>
-    	<th>256852</th>
-		<th>4141</th>
+		<th>9577</th>
+		<th>1461</th>
+		<th>447</th>
+		<th>7669</th>
+		<th>1413</th>
+    	<th>254907</th>
+		<th>4126</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $230,927<br>Estimated Schedule Effort (organic) 7.88 months<br>Estimated People Required (organic) 2.60<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $229,388<br>Estimated Schedule Effort (organic) 7.86 months<br>Estimated People Required (organic) 2.59<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/cmd/badges/example.py
+++ b/cmd/badges/example.py
@@ -115,7 +115,7 @@ def clone_and_process(filename, url, path):
     os.chdir(gettempdir())
 
     rmtree(Path(gettempdir()) / 'scc-tmp-path')
-    git.exec_command('clone', '--depth=1', url, 'scc-tmp-path', cwd='/tmp')
+    git.exec_command('clone', '--depth=1', url, 'scc-tmp-path', cwd=gettempdir())
 
     os.system('./scc -f json -o ' + str(Path(gettempdir()) / filename) + ' scc-tmp-path')
 

--- a/cmd/badges/main.go
+++ b/cmd/badges/main.go
@@ -88,23 +88,17 @@ func calculate(category string, wage int, res []processor.LanguageSummary) (stri
 	var value int64
 
 	switch category {
-	case "codes":
-		fallthrough
-	case "code":
+	case "code", "codes":
 		title = "Code lines"
 		for _, x := range res {
 			value += x.Code
 		}
-	case "blank":
-		fallthrough
-	case "blanks":
+	case "blank", "blanks":
 		title = "Blank lines"
 		for _, x := range res {
 			value += x.Blank
 		}
-	case "comment":
-		fallthrough
-	case "comments":
+	case "comment", "comments":
 		title = "Comments"
 		for _, x := range res {
 			value += x.Comment
@@ -116,9 +110,7 @@ func calculate(category string, wage int, res []processor.LanguageSummary) (stri
 		}
 
 		value = int64(estimateCost(value, wage))
-	case "lines": // lines is the default
-		fallthrough
-	case "line": // lines is the default
+	case "line", "lines": // lines is the default
 		fallthrough
 	default:
 		//

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -76,28 +76,28 @@ var openMetricsSummaryRecordFormat = "scc_%s{language=\"%s\"} %d\n"
 var openMetricsFileRecordFormat = "scc_%s{language=\"%s\",file=\"%s\"} %d\n"
 
 func sortSummaryFiles(summary *LanguageSummary) {
-	switch {
-	case SortBy == "name" || SortBy == "names" || SortBy == "language" || SortBy == "languages" || SortBy == "lang":
+	switch SortBy {
+	case "name", "names", "language", "languages", "lang", "langs":
 		slices.SortFunc(summary.Files, func(a, b *FileJob) int {
 			return strings.Compare(a.Location, b.Location)
 		})
-	case SortBy == "line" || SortBy == "lines":
+	case "line", "lines":
 		slices.SortFunc(summary.Files, func(a, b *FileJob) int {
 			return cmp.Compare(b.Lines, a.Lines)
 		})
-	case SortBy == "blank" || SortBy == "blanks":
+	case "blank", "blanks":
 		slices.SortFunc(summary.Files, func(a, b *FileJob) int {
 			return cmp.Compare(b.Blank, a.Blank)
 		})
-	case SortBy == "code" || SortBy == "codes":
+	case "code", "codes":
 		slices.SortFunc(summary.Files, func(a, b *FileJob) int {
 			return cmp.Compare(b.Code, a.Code)
 		})
-	case SortBy == "comment" || SortBy == "comments":
+	case "comment", "comments":
 		slices.SortFunc(summary.Files, func(a, b *FileJob) int {
 			return cmp.Compare(b.Comment, a.Comment)
 		})
-	case SortBy == "complexity" || SortBy == "complexitys" || SortBy == "comp":
+	case "complexity", "complexitys", "comp":
 		slices.SortFunc(summary.Files, func(a, b *FileJob) int {
 			return cmp.Compare(b.Complexity, a.Complexity)
 		})
@@ -341,46 +341,46 @@ func toCSVSummary(input chan *FileJob) string {
 func getRecordsSortFunc() func(a, b []string) int {
 	// Cater for the common case of adding plural even for those options that don't make sense
 	// as it's quite common for those who English is not a first language to make a simple mistake
-	switch {
-	case SortBy == "name" || SortBy == "names":
+	switch SortBy {
+	case "name", "names":
 		return func(a, b []string) int {
 			return strings.Compare(a[2], b[2])
 		}
-	case SortBy == "language" || SortBy == "languages":
+	case "language", "languages", "lang", "langs":
 		return func(a, b []string) int {
 			return strings.Compare(a[0], b[0])
 		}
-	case SortBy == "line" || SortBy == "lines":
+	case "line", "lines":
 		return func(a, b []string) int {
 			i1, _ := strconv.ParseInt(a[3], 10, 64)
 			i2, _ := strconv.ParseInt(b[3], 10, 64)
 			return cmp.Compare(i2, i1)
 		}
-	case SortBy == "blank" || SortBy == "blanks":
+	case "blank", "blanks":
 		return func(a, b []string) int {
 			i1, _ := strconv.ParseInt(a[6], 10, 64)
 			i2, _ := strconv.ParseInt(b[6], 10, 64)
 			return cmp.Compare(i2, i1)
 		}
-	case SortBy == "code" || SortBy == "codes":
+	case "code", "codes":
 		return func(a, b []string) int {
 			i1, _ := strconv.ParseInt(a[4], 10, 64)
 			i2, _ := strconv.ParseInt(b[4], 10, 64)
 			return cmp.Compare(i2, i1)
 		}
-	case SortBy == "comment" || SortBy == "comments":
+	case "comment", "comments":
 		return func(a, b []string) int {
 			i1, _ := strconv.ParseInt(a[5], 10, 64)
 			i2, _ := strconv.ParseInt(b[5], 10, 64)
 			return cmp.Compare(i2, i1)
 		}
-	case SortBy == "complexity" || SortBy == "complexitys":
+	case "complexity", "complexitys":
 		return func(a, b []string) int {
 			i1, _ := strconv.ParseInt(a[7], 10, 64)
 			i2, _ := strconv.ParseInt(b[7], 10, 64)
 			return cmp.Compare(i2, i1)
 		}
-	case SortBy == "byte" || SortBy == "bytes":
+	case "byte", "bytes":
 		return func(a, b []string) int {
 			i1, _ := strconv.ParseInt(a[8], 10, 64)
 			i2, _ := strconv.ParseInt(b[8], 10, 64)
@@ -919,38 +919,7 @@ func fileSummarizeLong(input chan *FileJob) string {
 		language = append(language, summary)
 	}
 
-	// Cater for the common case of adding plural even for those options that don't make sense
-	// as it's quite common for those who English is not a first language to make a simple mistake
-	switch {
-	case SortBy == "name" || SortBy == "names" || SortBy == "language" || SortBy == "langs":
-		slices.SortFunc(language, func(a, b LanguageSummary) int {
-			return strings.Compare(a.Name, b.Name)
-		})
-	case SortBy == "line" || SortBy == "lines":
-		slices.SortFunc(language, func(a, b LanguageSummary) int {
-			return cmp.Compare(b.Lines, a.Lines)
-		})
-	case SortBy == "blank" || SortBy == "blanks":
-		slices.SortFunc(language, func(a, b LanguageSummary) int {
-			return cmp.Compare(b.Blank, a.Blank)
-		})
-	case SortBy == "code" || SortBy == "codes":
-		slices.SortFunc(language, func(a, b LanguageSummary) int {
-			return cmp.Compare(b.Code, a.Code)
-		})
-	case SortBy == "comment" || SortBy == "comments":
-		slices.SortFunc(language, func(a, b LanguageSummary) int {
-			return cmp.Compare(b.Comment, a.Comment)
-		})
-	case SortBy == "complexity" || SortBy == "complexitys":
-		slices.SortFunc(language, func(a, b LanguageSummary) int {
-			return cmp.Compare(b.Complexity, a.Complexity)
-		})
-	default:
-		slices.SortFunc(language, func(a, b LanguageSummary) int {
-			return cmp.Compare(b.Count, a.Count)
-		})
-	}
+	language = sortLanguageSummary(language)
 
 	startTime := makeTimestampMilli()
 	for _, summary := range language {
@@ -1263,14 +1232,7 @@ func maxIn(i []int) int {
 		return 0
 	}
 
-	m := i[0]
-	for _, x := range i {
-		if x > m {
-			m = x
-		}
-	}
-
-	return m
+	return slices.Max(i)
 }
 
 func meanIn(i []int) int {
@@ -1382,16 +1344,10 @@ func isLeapYear(year int) bool {
 	leapFlag := false
 	if year%4 == 0 {
 		if year%100 == 0 {
-			if year%400 == 0 {
-				leapFlag = true
-			} else {
-				leapFlag = false
-			}
+			leapFlag = year%400 == 0
 		} else {
 			leapFlag = true
 		}
-	} else {
-		leapFlag = false
 	}
 	return leapFlag
 }
@@ -1456,40 +1412,40 @@ func sortLanguageSummary(language []LanguageSummary) []LanguageSummary {
 	// as it's quite common for those who English is not a first language to make a simple mistake
 	// NB in any non name cases if the values are the same we sort by name to ensure
 	// deterministic output
-	switch {
-	case SortBy == "name" || SortBy == "names" || SortBy == "language" || SortBy == "languages":
+	switch SortBy {
+	case "name", "names", "language", "languages", "lang", "langs":
 		slices.SortFunc(language, func(a, b LanguageSummary) int {
 			return strings.Compare(a.Name, b.Name)
 		})
-	case SortBy == "line" || SortBy == "lines":
+	case "line", "lines":
 		slices.SortFunc(language, func(a, b LanguageSummary) int {
 			if order := cmp.Compare(b.Lines, a.Lines); order != 0 {
 				return order
 			}
 			return strings.Compare(a.Name, b.Name)
 		})
-	case SortBy == "blank" || SortBy == "blanks":
+	case "blank", "blanks":
 		slices.SortFunc(language, func(a, b LanguageSummary) int {
 			if order := cmp.Compare(b.Blank, a.Blank); order != 0 {
 				return order
 			}
 			return strings.Compare(a.Name, b.Name)
 		})
-	case SortBy == "code" || SortBy == "codes":
+	case "code", "codes":
 		slices.SortFunc(language, func(a, b LanguageSummary) int {
 			if order := cmp.Compare(b.Code, a.Code); order != 0 {
 				return order
 			}
 			return strings.Compare(a.Name, b.Name)
 		})
-	case SortBy == "comment" || SortBy == "comments":
+	case "comment", "comments":
 		slices.SortFunc(language, func(a, b LanguageSummary) int {
 			if order := cmp.Compare(b.Comment, a.Comment); order != 0 {
 				return order
 			}
 			return strings.Compare(a.Name, b.Name)
 		})
-	case SortBy == "complexity" || SortBy == "complexitys":
+	case "complexity", "complexitys":
 		slices.SortFunc(language, func(a, b LanguageSummary) int {
 			if order := cmp.Compare(b.Complexity, a.Complexity); order != 0 {
 				return order


### PR DESCRIPTION
- simplify the usage of switch statements
- use "lang" and "langs" as aliases for "language" (these aliases are already used in existing code)
- reuse sortLanguageSummary
- use gettempdir to fix a warning about directly using the '/tmp' path