### PR TITLE
Use json-iterator/go for all JSON operations

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>27</th>
-		<th>9578</th>
-		<th>1462</th>
+		<th>9584</th>
+		<th>1464</th>
 		<th>447</th>
-		<th>7669</th>
+		<th>7673</th>
 		<th>1413</th>
-		<th>255238</th>
-		<th>4126</th>
+		<th>255539</th>
+		<th>4128</th>
 	</tr><tr>
 		<td>processor/workers_test.go</td>
 		<td></td>
@@ -33,13 +33,13 @@
 	</tr><tr>
 		<td>processor/formatters.go</td>
 		<td></td>
-		<td>1517</td>
+		<td>1519</td>
 		<td>208</td>
 		<td>39</td>
-		<td>1270</td>
+		<td>1272</td>
 		<td>163</td>
-	    <td>44230</td>
-		<td>784</td>
+	    <td>44361</td>
+		<td>785</td>
 	</tr><tr>
 		<td>processor/formatters_test.go</td>
 		<td></td>
@@ -93,13 +93,13 @@
 	</tr><tr>
 		<td>cmd/badges/main.go</td>
 		<td></td>
-		<td>374</td>
+		<td>375</td>
 		<td>60</td>
 		<td>17</td>
-		<td>297</td>
+		<td>298</td>
 		<td>59</td>
-	    <td>9571</td>
-		<td>239</td>
+	    <td>9660</td>
+		<td>240</td>
 	</tr><tr>
 		<td>processor/workers_tokei_test.go</td>
 		<td></td>
@@ -213,13 +213,13 @@
 	</tr><tr>
 		<td>scripts/include.go</td>
 		<td></td>
-		<td>84</td>
-		<td>16</td>
+		<td>87</td>
+		<td>18</td>
 		<td>9</td>
-		<td>59</td>
+		<td>60</td>
 		<td>19</td>
-	    <td>2207</td>
-		<td>62</td>
+	    <td>2288</td>
+		<td>63</td>
 	</tr><tr>
 		<td>processor/filereader.go</td>
 		<td></td>
@@ -294,15 +294,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>27</th>
-		<th>9578</th>
-		<th>1462</th>
+		<th>9584</th>
+		<th>1464</th>
 		<th>447</th>
-		<th>7669</th>
+		<th>7673</th>
 		<th>1413</th>
-    	<th>255238</th>
-		<th>4126</th>
+    	<th>255539</th>
+		<th>4128</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $229,388<br>Estimated Schedule Effort (organic) 7.86 months<br>Estimated People Required (organic) 2.59<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $229,513<br>Estimated Schedule Effort (organic) 7.86 months<br>Estimated People Required (organic) 2.59<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/cmd/badges/main.go
+++ b/cmd/badges/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	"github.com/boyter/scc/v3/processor"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/rs/zerolog/log"
 )
 
@@ -25,6 +25,7 @@ var (
 	cache             = NewSimpleCache(1000, 86400)
 	countingSemaphore = make(chan bool, 1)
 	tmpDir            = os.TempDir()
+	json              = jsoniter.ConfigCompatibleWithStandardLibrary
 )
 
 func main() {

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"cmp"
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -17,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/mattn/go-runewidth"
 
 	glanguage "golang.org/x/text/language"
@@ -244,6 +244,7 @@ func toJSON(input chan *FileJob) string {
 	language := aggregateLanguageSummary(input)
 	language = sortLanguageSummary(language)
 
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	jsonString, _ := json.Marshal(language)
 
 	if Debug {
@@ -272,6 +273,7 @@ func toJSON2(input chan *FileJob) string {
 
 	cost, schedule, people := esstimateCostScheduleMonths(sumCode)
 
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	jsonString, _ := json.Marshal(Json2{
 		LanguageSummary:         language,
 		EstimatedCost:           cost,

--- a/scripts/include.go
+++ b/scripts/include.go
@@ -6,14 +6,17 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 const constantsFile = "./processor/constants.go"
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 // Reads all .json files in the current folder
 // and encodes them as strings literals in constants.go


### PR DESCRIPTION
Currently, we have two JSON libraries in the code base: "encoding/json" and "github.com/json-iterator/go". Use one of them is completely enough.

The "json-iterator/go" is faster than the stdlib and uses less memory. So we choose the fast one for all JSON operations.

It also reduces the binary file size. For an example on Linux AMD64 with Go1.22.7, the binary file change is `8988568 -> 8811060 bytes`, more than 150 kib was reduced.