### PR TITLE
Add a newline to output files

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>27</th>
-		<th>9584</th>
+		<th>9585</th>
 		<th>1464</th>
 		<th>447</th>
-		<th>7673</th>
+		<th>7674</th>
 		<th>1413</th>
-		<th>255541</th>
-		<th>4129</th>
+		<th>255540</th>
+		<th>4127</th>
 	</tr><tr>
 		<td>processor/workers_test.go</td>
 		<td></td>
@@ -28,7 +28,7 @@
 		<td>33</td>
 		<td>1257</td>
 		<td>287</td>
-	    <td>32293</td>
+		<td>32293</td>
 		<td>525</td>
 	</tr><tr>
 		<td>processor/formatters.go</td>
@@ -38,17 +38,17 @@
 		<td>39</td>
 		<td>1272</td>
 		<td>163</td>
-	    <td>44361</td>
-		<td>785</td>
+		<td>44359</td>
+		<td>783</td>
 	</tr><tr>
 		<td>processor/formatters_test.go</td>
 		<td></td>
-		<td>1463</td>
+		<td>1464</td>
 		<td>156</td>
 		<td>3</td>
-		<td>1304</td>
+		<td>1305</td>
 		<td>120</td>
-	    <td>34174</td>
+		<td>34175</td>
 		<td>385</td>
 	</tr><tr>
 		<td>processor/workers.go</td>
@@ -58,7 +58,7 @@
 		<td>91</td>
 		<td>651</td>
 		<td>225</td>
-	    <td>25570</td>
+		<td>25570</td>
 		<td>494</td>
 	</tr><tr>
 		<td>processor/processor.go</td>
@@ -68,7 +68,7 @@
 		<td>104</td>
 		<td>430</td>
 		<td>94</td>
-	    <td>19510</td>
+		<td>19510</td>
 		<td>440</td>
 	</tr><tr>
 		<td>main.go</td>
@@ -78,7 +78,7 @@
 		<td>6</td>
 		<td>416</td>
 		<td>8</td>
-	    <td>9726</td>
+		<td>9726</td>
 		<td>271</td>
 	</tr><tr>
 		<td>processor/detector_test.go</td>
@@ -88,7 +88,7 @@
 		<td>2</td>
 		<td>304</td>
 		<td>101</td>
-	    <td>7258</td>
+		<td>7258</td>
 		<td>149</td>
 	</tr><tr>
 		<td>cmd/badges/main.go</td>
@@ -98,7 +98,7 @@
 		<td>17</td>
 		<td>298</td>
 		<td>59</td>
-	    <td>9660</td>
+		<td>9660</td>
 		<td>240</td>
 	</tr><tr>
 		<td>processor/workers_tokei_test.go</td>
@@ -108,7 +108,7 @@
 		<td>2</td>
 		<td>210</td>
 		<td>40</td>
-	    <td>4027</td>
+		<td>4027</td>
 		<td>125</td>
 	</tr><tr>
 		<td>processor/detector.go</td>
@@ -118,7 +118,7 @@
 		<td>33</td>
 		<td>160</td>
 		<td>57</td>
-	    <td>6243</td>
+		<td>6243</td>
 		<td>152</td>
 	</tr><tr>
 		<td>processor/file_test.go</td>
@@ -128,7 +128,7 @@
 		<td>1</td>
 		<td>162</td>
 		<td>37</td>
-	    <td>4585</td>
+		<td>4585</td>
 		<td>97</td>
 	</tr><tr>
 		<td>processor/structs.go</td>
@@ -138,7 +138,7 @@
 		<td>18</td>
 		<td>160</td>
 		<td>17</td>
-	    <td>5883</td>
+		<td>5883</td>
 		<td>139</td>
 	</tr><tr>
 		<td>cmd/badges/main_test.go</td>
@@ -148,7 +148,7 @@
 		<td>0</td>
 		<td>193</td>
 		<td>10</td>
-	    <td>4088</td>
+		<td>4088</td>
 		<td>106</td>
 	</tr><tr>
 		<td>processor/workers_regression_test.go</td>
@@ -158,7 +158,7 @@
 		<td>5</td>
 		<td>146</td>
 		<td>40</td>
-	    <td>3402</td>
+		<td>3402</td>
 		<td>93</td>
 	</tr><tr>
 		<td>processor/file.go</td>
@@ -168,7 +168,7 @@
 		<td>16</td>
 		<td>127</td>
 		<td>50</td>
-	    <td>3766</td>
+		<td>3766</td>
 		<td>99</td>
 	</tr><tr>
 		<td>cmd/badges/simplecache.go</td>
@@ -178,7 +178,7 @@
 		<td>13</td>
 		<td>120</td>
 		<td>20</td>
-	    <td>3070</td>
+		<td>3070</td>
 		<td>94</td>
 	</tr><tr>
 		<td>processor/processor_test.go</td>
@@ -188,7 +188,7 @@
 		<td>1</td>
 		<td>114</td>
 		<td>21</td>
-	    <td>2573</td>
+		<td>2573</td>
 		<td>66</td>
 	</tr><tr>
 		<td>cmd/badges/simplecache_test.go</td>
@@ -198,7 +198,7 @@
 		<td>3</td>
 		<td>78</td>
 		<td>17</td>
-	    <td>2030</td>
+		<td>2030</td>
 		<td>53</td>
 	</tr><tr>
 		<td>processor/structs_test.go</td>
@@ -208,7 +208,7 @@
 		<td>1</td>
 		<td>84</td>
 		<td>10</td>
-	    <td>1982</td>
+		<td>1982</td>
 		<td>57</td>
 	</tr><tr>
 		<td>scripts/include.go</td>
@@ -218,7 +218,7 @@
 		<td>9</td>
 		<td>60</td>
 		<td>19</td>
-	    <td>2288</td>
+		<td>2288</td>
 		<td>63</td>
 	</tr><tr>
 		<td>processor/filereader.go</td>
@@ -228,7 +228,7 @@
 		<td>10</td>
 		<td>32</td>
 		<td>6</td>
-	    <td>1316</td>
+		<td>1316</td>
 		<td>37</td>
 	</tr><tr>
 		<td>processor/cocomo.go</td>
@@ -238,18 +238,8 @@
 		<td>18</td>
 		<td>19</td>
 		<td>0</td>
-	    <td>2209</td>
+		<td>2209</td>
 		<td>35</td>
-	</tr><tr>
-		<td>processor/bloom.go</td>
-		<td></td>
-		<td>37</td>
-		<td>7</td>
-		<td>12</td>
-		<td>18</td>
-		<td>2</td>
-	    <td>1062</td>
-		<td>29</td>
 	</tr><tr>
 		<td>processor/cocomo_test.go</td>
 		<td></td>
@@ -258,8 +248,18 @@
 		<td>4</td>
 		<td>25</td>
 		<td>6</td>
-	    <td>686</td>
+		<td>686</td>
 		<td>23</td>
+	</tr><tr>
+		<td>processor/bloom.go</td>
+		<td></td>
+		<td>37</td>
+		<td>7</td>
+		<td>12</td>
+		<td>18</td>
+		<td>2</td>
+		<td>1062</td>
+		<td>29</td>
 	</tr><tr>
 		<td>processor/helpers_test.go</td>
 		<td></td>
@@ -268,7 +268,7 @@
 		<td>1</td>
 		<td>19</td>
 		<td>4</td>
-	    <td>434</td>
+		<td>434</td>
 		<td>18</td>
 	</tr><tr>
 		<td>processor/helpers.go</td>
@@ -278,7 +278,7 @@
 		<td>4</td>
 		<td>10</td>
 		<td>0</td>
-	    <td>378</td>
+		<td>378</td>
 		<td>14</td>
 	</tr><tr>
 		<td>processor/constants.go</td>
@@ -288,21 +288,21 @@
 		<td>1</td>
 		<td>4</td>
 		<td>0</td>
-	    <td>22967</td>
+		<td>22967</td>
 		<td>6</td>
 	</tr></tbody>
 	<tfoot><tr>
 		<th>Total</th>
 		<th>27</th>
-		<th>9584</th>
+		<th>9585</th>
 		<th>1464</th>
 		<th>447</th>
-		<th>7673</th>
+		<th>7674</th>
 		<th>1413</th>
-    	<th>255541</th>
-		<th>4129</th>
+		<th>255540</th>
+		<th>4127</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $229,513<br>Estimated Schedule Effort (organic) 7.86 months<br>Estimated People Required (organic) 2.59<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $229,545<br>Estimated Schedule Effort (organic) 7.86 months<br>Estimated People Required (organic) 2.59<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -476,7 +476,7 @@ func toOpenMetricsFiles(input chan *FileJob) string {
 		fmt.Fprintf(sb, openMetricsFileRecordFormat, "complexity", file.Language, filename, file.Complexity)
 		fmt.Fprintf(sb, openMetricsFileRecordFormat, "bytes", file.Language, filename, file.Bytes)
 	}
-	sb.WriteString("# EOF")
+	sb.WriteString("# EOF\n")
 	return sb.String()
 }
 
@@ -513,7 +513,7 @@ func toCSVStream(input chan *FileJob) string {
 func toHtml(input chan *FileJob) string {
 	return `<html lang="en"><head><meta charset="utf-8" /><title>scc html output</title><style>table { border-collapse: collapse; }td, th { border: 1px solid #999; padding: 0.5rem; text-align: left;}</style></head><body>` +
 		toHtmlTable(input) +
-		`</body></html>`
+		"</body></html>\n"
 }
 
 func toHtmlTable(input chan *FileJob) string {
@@ -612,7 +612,7 @@ func toHtmlTable(input chan *FileJob) string {
 		<td>%d</td>
 		<td>%d</td>
 		<td>%d</td>
-	    <td>%d</td>
+		<td>%d</td>
 		<td>%d</td>
 	</tr>`, res.Location, res.Lines, res.Blank, res.Comment, res.Code, res.Complexity, res.Bytes, res.Uloc)
 			}
@@ -629,7 +629,7 @@ func toHtmlTable(input chan *FileJob) string {
 		<th>%d</th>
 		<th>%d</th>
 		<th>%d</th>
-    	<th>%d</th>
+		<th>%d</th>
 		<th>%d</th>
 	</tr>`, sumFiles, sumLines, sumBlank, sumComment, sumCode, sumComplexity, sumBytes, len(ulocGlobalCount))
 

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -1044,7 +1044,8 @@ scc_comments{language="Go",file="C:\\bbbb.go"} 1000
 scc_blanks{language="Go",file="C:\\bbbb.go"} 1000
 scc_complexity{language="Go",file="C:\\bbbb.go"} 1000
 scc_bytes{language="Go",file="C:\\bbbb.go"} 1000
-# EOF`
+# EOF
+`
 
 	if res != expectedResult {
 		t.Error("Expected OpenMetrics return", res)


### PR DESCRIPTION
Linux asks all text files end with a newline. Git also need this:
![image](https://github.com/user-attachments/assets/594c1b2a-ff15-4066-a2e6-d0a3b9739b78)


Fix some indentations that mixed tabs and spaces.