### PR TITLE
Use a faster method to convert ints to strings

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -18,8 +18,8 @@
 		<th>447</th>
 		<th>7678</th>
 		<th>1413</th>
-		<th>256008</th>
-		<th>4131</th>
+		<th>256040</th>
+		<th>4138</th>
 	</tr><tr>
 		<td>processor/workers_test.go</td>
 		<td></td>
@@ -38,8 +38,8 @@
 		<td>39</td>
 		<td>1272</td>
 		<td>163</td>
-		<td>44359</td>
-		<td>783</td>
+		<td>44422</td>
+		<td>790</td>
 	</tr><tr>
 		<td>processor/formatters_test.go</td>
 		<td></td>
@@ -198,7 +198,7 @@
 		<td>3</td>
 		<td>78</td>
 		<td>17</td>
-		<td>2030</td>
+		<td>1999</td>
 		<td>53</td>
 	</tr><tr>
 		<td>processor/structs_test.go</td>
@@ -299,8 +299,8 @@
 		<th>447</th>
 		<th>7678</th>
 		<th>1413</th>
-		<th>256008</th>
-		<th>4131</th>
+		<th>256040</th>
+		<th>4138</th>
 	</tr>
 	<tr>
 		<th colspan="9">Estimated Cost to Develop (organic) $229,670<br>Estimated Schedule Effort (organic) 7.86 months<br>Estimated People Required (organic) 2.59<br></th>

--- a/cmd/badges/simplecache_test.go
+++ b/cmd/badges/simplecache_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -11,12 +11,12 @@ func TestSimpleCache_Add(t *testing.T) {
 	simpleCache := NewSimpleCache(5, 60)
 
 	for i := 0; i < 5; i++ {
-		simpleCache.Add(fmt.Sprintf("%d", i), []byte{})
+		simpleCache.Add(strconv.Itoa(i), []byte{})
 	}
 
 	for i := 0; i < 4; i++ {
 		for j := 0; j < 5; j++ {
-			simpleCache.Get(fmt.Sprintf("%d", i))
+			simpleCache.Get(strconv.Itoa(i))
 		}
 	}
 
@@ -27,7 +27,7 @@ func TestSimpleCache_Multiple(t *testing.T) {
 	simpleCache := NewSimpleCache(10, 60)
 
 	for i := 0; i < 500; i++ {
-		simpleCache.Add(fmt.Sprintf("%d", i), []byte{})
+		simpleCache.Add(strconv.Itoa(i), []byte{})
 	}
 
 	simpleCache.Add("test-key", []byte{})
@@ -41,9 +41,9 @@ func TestSimpleCache_MultipleLarge(t *testing.T) {
 	simpleCache := NewSimpleCache(1000, 60)
 
 	for i := 0; i < 500000; i++ {
-		simpleCache.Add(fmt.Sprintf("%d", i), []byte{})
+		simpleCache.Add(strconv.Itoa(i), []byte{})
 		simpleCache.Add("10", []byte{})
-		simpleCache.Get(fmt.Sprintf("%d", i))
+		simpleCache.Get(strconv.Itoa(i))
 		simpleCache.Get("10")
 		simpleCache.Get("10")
 	}
@@ -65,7 +65,7 @@ func TestSimpleCache_AgeOut(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
-		simpleCache.Add(fmt.Sprintf("%d", i), []byte{})
+		simpleCache.Add(strconv.Itoa(i), []byte{})
 	}
 
 	// advance time
@@ -86,7 +86,7 @@ func TestSimpleCache_AgeOutTime(t *testing.T) {
 	simpleCache := NewSimpleCache(100, 1)
 
 	for i := 0; i < 10; i++ {
-		simpleCache.Add(fmt.Sprintf("%d", i), []byte{})
+		simpleCache.Add(strconv.Itoa(i), []byte{})
 	}
 
 	time.Sleep(1 * time.Second)

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -305,14 +305,14 @@ func toCSVSummary(input chan *FileJob) string {
 	for _, result := range language {
 		records = append(records, []string{
 			result.Name,
-			fmt.Sprint(result.Lines),
-			fmt.Sprint(result.Code),
-			fmt.Sprint(result.Comment),
-			fmt.Sprint(result.Blank),
-			fmt.Sprint(result.Complexity),
-			fmt.Sprint(result.Bytes),
-			fmt.Sprint(result.Count),
-			fmt.Sprint(len(ulocLanguageCount[result.Name])),
+			strconv.FormatInt(result.Lines, 10),
+			strconv.FormatInt(result.Code, 10),
+			strconv.FormatInt(result.Comment, 10),
+			strconv.FormatInt(result.Blank, 10),
+			strconv.FormatInt(result.Complexity, 10),
+			strconv.FormatInt(result.Bytes, 10),
+			strconv.FormatInt(result.Count, 10),
+			strconv.Itoa(len(ulocLanguageCount[result.Name])),
 		})
 	}
 
@@ -403,13 +403,13 @@ func toCSVFiles(input chan *FileJob) string {
 			result.Language,
 			result.Location,
 			result.Filename,
-			fmt.Sprint(result.Lines),
-			fmt.Sprint(result.Code),
-			fmt.Sprint(result.Comment),
-			fmt.Sprint(result.Blank),
-			fmt.Sprint(result.Complexity),
-			fmt.Sprint(result.Bytes),
-			fmt.Sprint(result.Uloc),
+			strconv.FormatInt(result.Lines, 10),
+			strconv.FormatInt(result.Code, 10),
+			strconv.FormatInt(result.Comment, 10),
+			strconv.FormatInt(result.Blank, 10),
+			strconv.FormatInt(result.Complexity, 10),
+			strconv.FormatInt(result.Bytes, 10),
+			strconv.Itoa(result.Uloc),
 		})
 	}
 
@@ -493,17 +493,17 @@ func toCSVStream(input chan *FileJob) string {
 		var location = "\"" + quoteRegex.ReplaceAllString(result.Location, "\"\"") + "\""
 		var filename = "\"" + quoteRegex.ReplaceAllString(result.Filename, "\"\"") + "\""
 
-		fmt.Printf("%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
+		fmt.Printf("%s,%s,%s,%d,%d,%d,%d,%d,%d,%d\n",
 			result.Language,
 			location,
 			filename,
-			fmt.Sprint(result.Lines),
-			fmt.Sprint(result.Code),
-			fmt.Sprint(result.Comment),
-			fmt.Sprint(result.Blank),
-			fmt.Sprint(result.Complexity),
-			fmt.Sprint(result.Bytes),
-			fmt.Sprint(result.Uloc),
+			result.Lines,
+			result.Code,
+			result.Comment,
+			result.Blank,
+			result.Complexity,
+			result.Bytes,
+			result.Uloc,
 		)
 	}
 


### PR DESCRIPTION
"strconv.FormatInt" is faster and does less allocations than "fmt.Sprint". Let's do the right thing with the right tools.

benchmark:

go version 1.23.4

```golang
func BenchmarkFmtSprint(b *testing.B) {
	for i := range b.N {
		_ = fmt.Sprint(i)
	}
}

func BenchmarkStrconv(b *testing.B) {
	for i := range b.N {
		strconv.FormatInt(int64(i), 10)
	}
}
```

![image](https://github.com/user-attachments/assets/7f663014-65b9-4866-b9c1-de0b3a38fda4)
