### PR TITLE
Add fedora install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Or if you have [Homebrew](https://brew.sh/) installed
 
 `$ brew install scc`
 
+#### Fedora
+
+Fedora Linux users can use a [COPR repository](https://copr.fedorainfracloud.org/coprs/lihaohong/scc/):
+
+`$ sudo dnf copr enable lihaohong/scc && sudo dnf install scc`
+
 #### MacPorts
 
 On macOS, you can also install via [MacPorts](https://www.macports.org)


### PR DESCRIPTION
Fix #589

Not sure where to put Fedora, so I'm just sticking it in the middle. 

It might be nicer to have the README organized with `<details>` and `<summary>` tags so that sections become collapsible and the page won't be too long to be navigable. Users would be able to quickly find information relevant to their own OS. For example:

<details>
<summary>

## Go Install

</summary>

You can install `scc` by using the standard go toolchain.

To install the latest stable version of scc:

`go install github.com/boyter/scc/v3@latest`

To install a development version:

`go install github.com/boyter/scc/v3@master`

Note that `scc` needs go version >= 1.22.
</details>

<details>
<summary>

## Linux

</summary>

### Snap

Lorem ipsum

### Flatpak

Lorem ipsum

### Fedora

Lorem ipsum

</details>

<details>
<summary>

## macOS

</summary>

### Macports

Lorem ipsum

</details>

<details>
<summary>

## Windows

</summary>

### Winget
Lorem ipsum
### Scoop
Lorem ipsum
### Choclatey
Lorem ipsum
</details>

<details>
<summary>

## Homebrew

</summary>

Lorem ipsum
</details>