### PR TITLE
Update devcontainer to support go1.24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Go",
-    "image": "mcr.microsoft.com/devcontainers/go:1.22",
+    "image": "mcr.microsoft.com/devcontainers/go:1.24",
     "customizations": {
         "codespaces": {
             "openFiles": [


### PR DESCRIPTION
"mcr.microsoft.com/devcontainers/go" finally released their go1.24 support.