### PR TITLE
Fix line comment count for nix (#611)

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -4456,7 +4456,7 @@
       "== "
     ],
     "extensions": ["nix"],
-    "line_comment": ["//"],
+    "line_comment": ["#"],
     "multi_line": [["/*", "*/"]],
     "quotes": [
       {

--- a/processor/constants.go
+++ b/processor/constants.go
@@ -7220,7 +7220,7 @@ var languageDatabase = map[string]Language{
 	},
 	"Nix": {
 		LineComment: []string{
-			"//",
+			"#",
 		},
 		ComplexityChecks: []string{
 			"for ",


### PR DESCRIPTION
Fixes the issue of line comments not being counted by using \# as the line comment symbol instead of //.
https://github.com/boyter/scc/issues/611

This contribution is licensed under the present MIT License.