### PR TITLE
Terraform: tfvars and tofu extensions

### DIFF
--- a/processor/constants.go
+++ b/processor/constants.go
@@ -11291,7 +11291,9 @@ var languageDatabase = map[string]Language{
 		},
 		Extensions: []string{
 			"tf",
+			"tfvars",
 			"tf.json",
+			"tofu",
 		},
 		ExtensionFile: false,
 		MultiLine: [][]string{


### PR DESCRIPTION
Missing "tfvars" extension
Added "tofu" extension used by the opentofu project (a terraform fork from Linux Foundation