### PR TITLE
feat: speed up specific languages test

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,12 +13,12 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>25</th>
-		<th>22671</th>
-		<th>1429</th>
+		<th>22673</th>
+		<th>1430</th>
 		<th>430</th>
-		<th>20812</th>
+		<th>20813</th>
 		<th>1390</th>
-		<th>437916</th>
+		<th>437970</th>
 		<th>6095</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
@@ -43,12 +43,12 @@
 	</tr><tr>
 		<td>processor/formatters.go</td>
 		<td></td>
-		<td>1519</td>
-		<td>208</td>
+		<td>1521</td>
+		<td>209</td>
 		<td>39</td>
-		<td>1272</td>
+		<td>1273</td>
 		<td>163</td>
-		<td>44422</td>
+		<td>44476</td>
 		<td>790</td>
 	</tr><tr>
 		<td>processor/formatters_test.go</td>
@@ -274,15 +274,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>25</th>
-		<th>22671</th>
-		<th>1429</th>
+		<th>22673</th>
+		<th>1430</th>
 		<th>430</th>
-		<th>20812</th>
+		<th>20813</th>
 		<th>1390</th>
-		<th>437916</th>
+		<th>437970</th>
 		<th>6095</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $654,372<br>Estimated Schedule Effort (organic) 11.71 months<br>Estimated People Required (organic) 4.97<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $654,405<br>Estimated Schedule Effort (organic) 11.71 months<br>Estimated People Required (organic) 4.97<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/test-all.sh
+++ b/test-all.sh
@@ -1028,9 +1028,10 @@ specificLanguages=(
     'ZoKrates '
     'Zsh '
 )
+SPECIFIC_LANG_TEST_RESULT=$(./scc "examples/language/" --no-scc-ignore)
 for i in "${specificLanguages[@]}"
 do
-    if ./scc "examples/language/" --no-scc-ignore | grep -q "$i"; then
+    if echo "$SPECIFIC_LANG_TEST_RESULT" | grep -q "$i"; then
         echo -e "${GREEN}PASSED $i Language Check"
     else
         echo -e "${RED}======================================================="


### PR DESCRIPTION
Run `./scc "examples/language/" --no-scc-ignore` once then reuse its result on the specific languages test. Otherwise we would need to run SCC hundreds of times over and over in an increasingly complex directory, and even though SCC is very fast it would significantly increase the time spent on testing.

The time taken to run `test-all.sh` on my laptop went down from 11.5s to 9.7s.