### PR TITLE
fix: fix CountStats performance

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>27</th>
-		<th>22681</th>
+		<th>22693</th>
 		<th>1431</th>
-		<th>430</th>
-		<th>20820</th>
-		<th>1359</th>
-		<th>438710</th>
-		<th>6146</th>
+		<th>434</th>
+		<th>20828</th>
+		<th>1363</th>
+		<th>438928</th>
+		<th>6148</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
 		<td></td>
@@ -63,13 +63,13 @@
 	</tr><tr>
 		<td>processor/workers.go</td>
 		<td></td>
-		<td>822</td>
+		<td>834</td>
 		<td>124</td>
-		<td>91</td>
-		<td>607</td>
-		<td>201</td>
-		<td>25179</td>
-		<td>489</td>
+		<td>95</td>
+		<td>615</td>
+		<td>205</td>
+		<td>25397</td>
+		<td>492</td>
 	</tr><tr>
 		<td>processor/processor.go</td>
 		<td></td>
@@ -251,16 +251,6 @@
 		<td>2209</td>
 		<td>35</td>
 	</tr><tr>
-		<td>processor/bloom.go</td>
-		<td></td>
-		<td>37</td>
-		<td>7</td>
-		<td>12</td>
-		<td>18</td>
-		<td>2</td>
-		<td>1062</td>
-		<td>29</td>
-	</tr><tr>
 		<td>processor/cocomo_test.go</td>
 		<td></td>
 		<td>37</td>
@@ -270,6 +260,16 @@
 		<td>6</td>
 		<td>686</td>
 		<td>23</td>
+	</tr><tr>
+		<td>processor/bloom.go</td>
+		<td></td>
+		<td>37</td>
+		<td>7</td>
+		<td>12</td>
+		<td>18</td>
+		<td>2</td>
+		<td>1062</td>
+		<td>29</td>
 	</tr><tr>
 		<td>processor/helpers_test.go</td>
 		<td></td>
@@ -294,15 +294,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>27</th>
-		<th>22681</th>
+		<th>22693</th>
 		<th>1431</th>
-		<th>430</th>
-		<th>20820</th>
-		<th>1359</th>
-		<th>438710</th>
-		<th>6146</th>
+		<th>434</th>
+		<th>20828</th>
+		<th>1363</th>
+		<th>438928</th>
+		<th>6148</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $654,636<br>Estimated Schedule Effort (organic) 11.71 months<br>Estimated People Required (organic) 4.97<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $654,900<br>Estimated Schedule Effort (organic) 11.71 months<br>Estimated People Required (organic) 4.97<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -518,7 +518,10 @@ func CountStats(fileJob *FileJob) {
 						return
 					}
 				}
-				printTraceF("%s line %d ended with state: %d: counted as code", fileJob.Location, fileJob.Lines, currentState)
+				if Trace {
+					// Don't remove the outside if-statements, for performance
+					printTraceF("%s line %d ended with state: %d: counted as code", fileJob.Location, fileJob.Lines, currentState)
+				}
 			case SComment, SMulticomment, SMulticommentBlank:
 				fileJob.Comment++
 				currentState = resetState(currentState)
@@ -527,7 +530,10 @@ func CountStats(fileJob *FileJob) {
 						return
 					}
 				}
-				printTraceF("%s line %d ended with state: %d: counted as comment", fileJob.Location, fileJob.Lines, currentState)
+				if Trace {
+					// Same as above
+					printTraceF("%s line %d ended with state: %d: counted as comment", fileJob.Location, fileJob.Lines, currentState)
+				}
 			case SBlank:
 				fileJob.Blank++
 				if fileJob.Callback != nil {
@@ -535,7 +541,10 @@ func CountStats(fileJob *FileJob) {
 						return
 					}
 				}
-				printTraceF("%s line %d ended with state: %d: counted as blank", fileJob.Location, fileJob.Lines, currentState)
+				if Trace {
+					// Same as above
+					printTraceF("%s line %d ended with state: %d: counted as blank", fileJob.Location, fileJob.Lines, currentState)
+				}
 			case SDocString:
 				fileJob.Comment++
 				if fileJob.Callback != nil {
@@ -543,7 +552,10 @@ func CountStats(fileJob *FileJob) {
 						return
 					}
 				}
-				printTraceF("%s line %d ended with state: %d: counted as comment", fileJob.Location, fileJob.Lines, currentState)
+				if Trace {
+					// Same as above
+					printTraceF("%s line %d ended with state: %d: counted as comment", fileJob.Location, fileJob.Lines, currentState)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The compiler is still not smart, branch-less code in `CountStats` casused a performance regression. I'll revert this part.

Other parts won't impact the speed.

Before:
<img width="629" alt="slow" src="https://github.com/user-attachments/assets/beda5f5f-a030-4ca7-85f6-4a525fd92522" />


Fixes:
<img width="788" alt="fix" src="https://github.com/user-attachments/assets/fdd20bb2-eee3-4ffa-ae64-3e59069e5116" />

After the revert the performance issue is fixed and we even become a little bit faster.

The compiler reports that these functions are inlined (I also detected the binary file, printXXX functions actually inlined and they were not in the symbol table), and theoretically there should be no performance difference. This is so wierd, so I left some comments on it.
