### PR TITLE
refactor: fix some golangci-lint warnings

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>27</th>
-		<th>22817</th>
+		<th>22824</th>
 		<th>1439</th>
 		<th>438</th>
-		<th>20940</th>
-		<th>1369</th>
-		<th>442455</th>
-		<th>6189</th>
+		<th>20947</th>
+		<th>1362</th>
+		<th>442622</th>
+		<th>6194</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
 		<td></td>
@@ -48,7 +48,7 @@
 		<td>31</td>
 		<td>1227</td>
 		<td>152</td>
-		<td>43071</td>
+		<td>43155</td>
 		<td>766</td>
 	</tr><tr>
 		<td>processor/formatters_test.go</td>
@@ -63,13 +63,13 @@
 	</tr><tr>
 		<td>processor/workers.go</td>
 		<td></td>
-		<td>834</td>
+		<td>835</td>
 		<td>124</td>
 		<td>95</td>
-		<td>615</td>
-		<td>205</td>
-		<td>25397</td>
-		<td>492</td>
+		<td>616</td>
+		<td>198</td>
+		<td>25365</td>
+		<td>493</td>
 	</tr><tr>
 		<td>processor/processor.go</td>
 		<td></td>
@@ -223,23 +223,23 @@
 	</tr><tr>
 		<td>scripts/include.go</td>
 		<td></td>
-		<td>88</td>
+		<td>92</td>
 		<td>19</td>
 		<td>5</td>
-		<td>64</td>
+		<td>68</td>
 		<td>19</td>
-		<td>2062</td>
-		<td>60</td>
+		<td>2140</td>
+		<td>64</td>
 	</tr><tr>
 		<td>processor/filereader.go</td>
 		<td></td>
-		<td>52</td>
+		<td>54</td>
 		<td>10</td>
 		<td>10</td>
-		<td>32</td>
+		<td>34</td>
 		<td>5</td>
-		<td>1316</td>
-		<td>37</td>
+		<td>1353</td>
+		<td>39</td>
 	</tr><tr>
 		<td>processor/cocomo.go</td>
 		<td></td>
@@ -294,15 +294,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>27</th>
-		<th>22817</th>
+		<th>22824</th>
 		<th>1439</th>
 		<th>438</th>
-		<th>20940</th>
-		<th>1369</th>
-		<th>442455</th>
-		<th>6189</th>
+		<th>20947</th>
+		<th>1362</th>
+		<th>442622</th>
+		<th>6194</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $658,598<br>Estimated Schedule Effort (organic) 11.74 months<br>Estimated People Required (organic) 4.99<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $658,829<br>Estimated Schedule Effort (organic) 11.74 months<br>Estimated People Required (organic) 4.99<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/processor/filereader.go
+++ b/processor/filereader.go
@@ -27,7 +27,9 @@ func (reader *FileReader) ReadFile(path string, size int) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error opening %s: %v", path, err)
 	}
-	defer fd.Close()
+	defer func(file *os.File) {
+		_ = file.Close()
+	}(fd)
 
 	// Generally, re-using the buffer is best. But, if we end up reading a huge
 	// file we would allocate an equally huge buffer. Rather than keep the huge

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -1257,14 +1257,14 @@ func calculateCocomoSLOCCount(sumCode int64, str *strings.Builder) {
 
 	p := gmessage.NewPrinter(glanguage.Make(os.Getenv("LANG")))
 
-	p.Fprintf(str, "Total Physical Source Lines of Code (SLOC)                     = %d\n", sumCode)
-	p.Fprintf(str, "Development Effort Estimate, Person-Years (Person-Months)      = %.2f (%.2f)\n", estimatedEffort/12, estimatedEffort)
-	p.Fprintf(str, " (Basic COCOMO model, Person-Months = %.2f*(KSLOC**%.2f)*%.2f)\n", projectType[CocomoProjectType][0], projectType[CocomoProjectType][1], EAF)
-	p.Fprintf(str, "Schedule Estimate, Years (Months)                              = %.2f (%.2f)\n", estimatedScheduleMonths/12, estimatedScheduleMonths)
-	p.Fprintf(str, " (Basic COCOMO model, Months = %.2f*(person-months**%.2f))\n", projectType[CocomoProjectType][2], projectType[CocomoProjectType][3])
-	p.Fprintf(str, "Estimated Average Number of Developers (Effort/Schedule)       = %.2f\n", estimatedPeopleRequired)
-	p.Fprintf(str, "Total Estimated Cost to Develop                                = %s%.0f\n", CurrencySymbol, estimatedCost)
-	p.Fprintf(str, " (average salary = %s%d/year, overhead = %.2f)\n", CurrencySymbol, AverageWage, Overhead)
+	_, _ = p.Fprintf(str, "Total Physical Source Lines of Code (SLOC)                     = %d\n", sumCode)
+	_, _ = p.Fprintf(str, "Development Effort Estimate, Person-Years (Person-Months)      = %.2f (%.2f)\n", estimatedEffort/12, estimatedEffort)
+	_, _ = p.Fprintf(str, " (Basic COCOMO model, Person-Months = %.2f*(KSLOC**%.2f)*%.2f)\n", projectType[CocomoProjectType][0], projectType[CocomoProjectType][1], EAF)
+	_, _ = p.Fprintf(str, "Schedule Estimate, Years (Months)                              = %.2f (%.2f)\n", estimatedScheduleMonths/12, estimatedScheduleMonths)
+	_, _ = p.Fprintf(str, " (Basic COCOMO model, Months = %.2f*(person-months**%.2f))\n", projectType[CocomoProjectType][2], projectType[CocomoProjectType][3])
+	_, _ = p.Fprintf(str, "Estimated Average Number of Developers (Effort/Schedule)       = %.2f\n", estimatedPeopleRequired)
+	_, _ = p.Fprintf(str, "Total Estimated Cost to Develop                                = %s%.0f\n", CurrencySymbol, estimatedCost)
+	_, _ = p.Fprintf(str, " (average salary = %s%d/year, overhead = %.2f)\n", CurrencySymbol, AverageWage, Overhead)
 }
 
 func calculateCocomo(sumCode int64, str *strings.Builder) {
@@ -1272,12 +1272,12 @@ func calculateCocomo(sumCode int64, str *strings.Builder) {
 
 	p := gmessage.NewPrinter(glanguage.Make(os.Getenv("LANG")))
 
-	p.Fprintf(str, "Estimated Cost to Develop (%s) %s%d\n", CocomoProjectType, CurrencySymbol, int64(estimatedCost))
-	p.Fprintf(str, "Estimated Schedule Effort (%s) %.2f months\n", CocomoProjectType, estimatedScheduleMonths)
+	_, _ = p.Fprintf(str, "Estimated Cost to Develop (%s) %s%d\n", CocomoProjectType, CurrencySymbol, int64(estimatedCost))
+	_, _ = p.Fprintf(str, "Estimated Schedule Effort (%s) %.2f months\n", CocomoProjectType, estimatedScheduleMonths)
 	if math.IsNaN(estimatedPeopleRequired) {
-		p.Fprintf(str, "Estimated People Required 1 Grandparent\n")
+		_, _ = p.Fprintf(str, "Estimated People Required 1 Grandparent\n")
 	} else {
-		p.Fprintf(str, "Estimated People Required (%s) %.2f\n", CocomoProjectType, estimatedPeopleRequired)
+		_, _ = p.Fprintf(str, "Estimated People Required (%s) %.2f\n", CocomoProjectType, estimatedPeopleRequired)
 	}
 }
 

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -99,11 +99,12 @@ func shouldProcess(currentByte, processBytesMask byte) bool {
 }
 
 func resetState(currentState int64) int64 {
-	if currentState == SMulticomment || currentState == SMulticommentCode {
+	switch currentState {
+	case SMulticomment, SMulticommentCode:
 		currentState = SMulticomment
-	} else if currentState == SString {
+	case SString:
 		currentState = SString
-	} else {
+	default:
 		currentState = SBlank
 	}
 

--- a/scripts/include.go
+++ b/scripts/include.go
@@ -38,7 +38,9 @@ func generateConstants() error {
 			if err != nil {
 				return fmt.Errorf("failed to open file '%s': %v", f.Name(), err)
 			}
-			defer f.Close()
+			defer func(file *os.File) {
+				_ = file.Close()
+			}(f)
 
 			data := map[string]processor.Language{}
 
@@ -71,7 +73,9 @@ func generateConstants() error {
 	if err != nil {
 		return fmt.Errorf("failed to open constants file: %v", err)
 	}
-	defer out.Close()
+	defer func(file *os.File) {
+		_ = file.Close()
+	}(out)
 
 	if _, err := out.Write(source); err != nil {
 		return fmt.Errorf("failed to write constants file %v", err)


### PR DESCRIPTION
Fix some warnings:

<img width="1408" height="675" alt="image" src="https://github.com/user-attachments/assets/03e9f8be-505b-425d-90a9-a35b22113ccd" />

I did not remove the unused code because it was added recently and maybe useful in future.
