### PR TITLE
fix: correct spacing padding

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>27</th>
-		<th>22909</th>
+		<th>22911</th>
 		<th>1439</th>
 		<th>438</th>
-		<th>21032</th>
+		<th>21034</th>
 		<th>1362</th>
-		<th>443958</th>
-		<th>6198</th>
+		<th>444089</th>
+		<th>6200</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
 		<td></td>
@@ -43,13 +43,13 @@
 	</tr><tr>
 		<td>processor/formatters.go</td>
 		<td></td>
-		<td>1459</td>
+		<td>1461</td>
 		<td>201</td>
 		<td>31</td>
-		<td>1227</td>
+		<td>1229</td>
 		<td>152</td>
-		<td>43155</td>
-		<td>766</td>
+		<td>43286</td>
+		<td>768</td>
 	</tr><tr>
 		<td>processor/formatters_test.go</td>
 		<td></td>
@@ -294,15 +294,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>27</th>
-		<th>22909</th>
+		<th>22911</th>
 		<th>1439</th>
 		<th>438</th>
-		<th>21032</th>
+		<th>21034</th>
 		<th>1362</th>
-		<th>443958</th>
-		<th>6198</th>
+		<th>444089</th>
+		<th>6200</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $661,637<br>Estimated Schedule Effort (organic) 11.76 months<br>Estimated People Required (organic) 5.00<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $661,703<br>Estimated Schedule Effort (organic) 11.76 months<br>Estimated People Required (organic) 5.00<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -30,20 +30,21 @@ var tabularShortBreakCi = "-----------------------------------------------------
 var tabularShortFormatHead = "%-15s %9s %11s %9s %9s %10s %10s\n"
 var tabularShortFormatBody = "%-15s %9d %11d %9d %9d %10d %10d\n"
 var tabularShortFormatFile = "%s %9d %9d %9d %10d %10d\n"
-var tabularShortFormatFileMaxMean = "MaxLine / MeanLine %11d %9d\n"
+var tabularShortFormatFileMaxMean = "MaxLine / MeanLine %6d %11d\n"
 var shortFormatFileTruncate = 26
 var shortNameTruncate = 15
-var tabularShortUlocLanguageFormatBody = "(ULOC) %33d\n"
-var tabularShortPercentLanguageFormatBody = "Percentage %18.1f%% %8.1f%% %7.1f%% %8.1f%% %7.1f%% %9.1f%%\n"
-var tabularShortUlocGlobalFormatBody = "Unique Lines of Code (ULOC) %12d\n"
+var tabularShortUlocLanguageFormatBody = "(ULOC) %30d\n"
+var tabularShortPercentLanguageFormatBody = "Percentage %13.1f%% %10.1f%% %8.1f%% %8.1f%% %9.1f%% %9.1f%%\n"
+var tabularShortUlocGlobalFormatBody = "Unique Lines of Code (ULOC) %9d\n"
+var tabularShortDrynessFormatBody = "DRYness %% %27.2f\n"
 
 var tabularShortFormatHeadNoComplexity = "%-21s %11s %11s %10s %11s %10s\n"
 var tabularShortFormatBodyNoComplexity = "%-21s %11d %11d %10d %11d %10d\n"
-var tabularShortFormatFileNoComplexity = "%s %11d %10d %11d %9d\n"
-var tabularShortFormatFileMaxMeanNoComplexity = "MaxLine / MeanLine %15d %11d\n"
+var tabularShortFormatFileNoComplexity = "%s %10d %10d %11d %10d\n"
+var tabularShortFormatFileMaxMeanNoComplexity = "MaxLine / MeanLine %14d %11d\n"
 var longNameTruncate = 22
-var tabularShortUlocLanguageFormatBodyNoComplexity = "(ULOC) %39d\n"
-var tabularShortPercentLanguageFormatBodyNoComplexity = "Percentage %22.1f%% %10.1f%% %9.1f%% %10.1f%% %8.1f%%\n"
+var tabularShortUlocLanguageFormatBodyNoComplexity = "(ULOC) %38d\n"
+var tabularShortPercentLanguageFormatBodyNoComplexity = "Percentage %21.1f%% %10.1f%% %9.1f%% %10.1f%% %9.1f%%\n"
 
 var tabularWideBreak = "─────────────────────────────────────────────────────────────────────────────────────────────────────────────\n"
 var tabularWideBreakCi = "-------------------------------------------------------------------------------------------------------------\n"
@@ -55,6 +56,7 @@ var wideFormatFileTruncate = 42
 var tabularWideUlocLanguageFormatBody = "(ULOC) %46d\n"
 var tabularWideUlocGlobalFormatBody = "Unique Lines of Code (ULOC) %25d\n"
 var tabularWideFormatBodyPercent = "Percentage %31.1f%% %8.1f%% %7.1f%% %8.1f%% %7.1f%% %9.1f%%\n"
+var tabularWideDrynessFormatBody = "DRYness %% %43.2f\n"
 
 var openMetricsMetadata = `# TYPE scc_files gauge
 # HELP scc_files Number of sourcecode files.
@@ -982,7 +984,7 @@ func fileSummarizeLong(input chan *FileJob) string {
 		_, _ = fmt.Fprintf(str, tabularWideUlocGlobalFormatBody, len(ulocGlobalCount))
 		if Dryness {
 			dryness := float64(len(ulocGlobalCount)) / float64(sumLines)
-			_, _ = fmt.Fprintf(str, "DRYness %% %43.2f\n", dryness)
+			_, _ = fmt.Fprintf(str, tabularWideDrynessFormatBody, dryness)
 		}
 		str.WriteString(getTabularWideBreak())
 	}
@@ -1201,7 +1203,7 @@ func fileSummarizeShort(input chan *FileJob) string {
 		_, _ = fmt.Fprintf(str, tabularShortUlocGlobalFormatBody, len(ulocGlobalCount))
 		if Dryness {
 			dryness := float64(len(ulocGlobalCount)) / float64(sumLines)
-			_, _ = fmt.Fprintf(str, "DRYness %% %30.2f\n", dryness)
+			_, _ = fmt.Fprintf(str, tabularShortDrynessFormatBody, dryness)
 		}
 		str.WriteString(getTabularShortBreak())
 	}


### PR DESCRIPTION
Fixes #635 

The display misalignment is caused by the missing changes of some output templates in #632. The issue can be resolved by aligning these templates according to the new width.

After fixing:

<img width="858" height="560" alt="image" src="https://github.com/user-attachments/assets/63557f93-8866-46a4-a8a2-f2daa46ff1d4" />

<img width="825" height="705" alt="image" src="https://github.com/user-attachments/assets/c68ba025-e810-4a47-8965-d3ebbafddc60" />

<img width="815" height="563" alt="image" src="https://github.com/user-attachments/assets/d23c8c34-32b1-4f75-a89d-d9f2b058ccea" />

<img width="837" height="690" alt="image" src="https://github.com/user-attachments/assets/d02461a5-e5c7-4ee0-bfc4-2288eec4590e" />


<img width="828" height="775" alt="image" src="https://github.com/user-attachments/assets/9084cd6c-5e86-43e3-8f3f-1b4b7a266d81" />

<img width="835" height="771" alt="image" src="https://github.com/user-attachments/assets/0a9f2bc6-986c-4426-8b76-d84fd60e9be0" />

<img width="804" height="586" alt="image" src="https://github.com/user-attachments/assets/30e46680-0a68-4b24-a751-a9807b8ae392" />


Additionally, I noticed that ULOC-related numbers aren't outputting in the local format. I'll address this issue in another pull request; this one focuses solely on fixing output alignment.

<img width="813" height="689" alt="image" src="https://github.com/user-attachments/assets/cea954a0-88e1-4a0a-84d7-d0a45ed6fe3c" />
