### PR TITLE
fix: fix sort for CSV outputs

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>27</th>
-		<th>22925</th>
-		<th>1439</th>
-		<th>438</th>
-		<th>21048</th>
-		<th>1362</th>
-		<th>444512</th>
-		<th>6202</th>
+		<th>23110</th>
+		<th>1442</th>
+		<th>442</th>
+		<th>21226</th>
+		<th>1369</th>
+		<th>449731</th>
+		<th>6246</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
 		<td></td>
@@ -41,25 +41,25 @@
 		<td>32293</td>
 		<td>525</td>
 	</tr><tr>
-		<td>processor/formatters.go</td>
-		<td></td>
-		<td>1461</td>
-		<td>201</td>
-		<td>31</td>
-		<td>1229</td>
-		<td>152</td>
-		<td>43371</td>
-		<td>768</td>
-	</tr><tr>
 		<td>processor/formatters_test.go</td>
 		<td></td>
-		<td>1415</td>
-		<td>146</td>
-		<td>3</td>
-		<td>1266</td>
-		<td>118</td>
-		<td>33190</td>
-		<td>360</td>
+		<td>1544</td>
+		<td>148</td>
+		<td>5</td>
+		<td>1391</td>
+		<td>124</td>
+		<td>36647</td>
+		<td>400</td>
+	</tr><tr>
+		<td>processor/formatters.go</td>
+		<td></td>
+		<td>1517</td>
+		<td>202</td>
+		<td>33</td>
+		<td>1282</td>
+		<td>153</td>
+		<td>45133</td>
+		<td>776</td>
 	</tr><tr>
 		<td>processor/workers.go</td>
 		<td></td>
@@ -201,16 +201,6 @@
 		<td>2771</td>
 		<td>80</td>
 	</tr><tr>
-		<td>processor/structs_test.go</td>
-		<td></td>
-		<td>96</td>
-		<td>11</td>
-		<td>1</td>
-		<td>84</td>
-		<td>10</td>
-		<td>1982</td>
-		<td>57</td>
-	</tr><tr>
 		<td>processor/trace.go</td>
 		<td></td>
 		<td>96</td>
@@ -220,6 +210,16 @@
 		<td>9</td>
 		<td>1957</td>
 		<td>58</td>
+	</tr><tr>
+		<td>processor/structs_test.go</td>
+		<td></td>
+		<td>96</td>
+		<td>11</td>
+		<td>1</td>
+		<td>84</td>
+		<td>10</td>
+		<td>1982</td>
+		<td>57</td>
 	</tr><tr>
 		<td>scripts/include.go</td>
 		<td></td>
@@ -294,15 +294,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>27</th>
-		<th>22925</th>
-		<th>1439</th>
-		<th>438</th>
-		<th>21048</th>
-		<th>1362</th>
-		<th>444512</th>
-		<th>6202</th>
+		<th>23110</th>
+		<th>1442</th>
+		<th>442</th>
+		<th>21226</th>
+		<th>1369</th>
+		<th>449731</th>
+		<th>6246</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $662,165<br>Estimated Schedule Effort (organic) 11.76 months<br>Estimated People Required (organic) 5.00<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $668,046<br>Estimated Schedule Effort (organic) 11.80 months<br>Estimated People Required (organic) 5.03<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -292,9 +292,65 @@ func toCSV(input chan *FileJob) string {
 	return toCSVSummary(input)
 }
 
+func getCSVSummarySortFunc(sortBy string) func(a, b []string) int {
+	// Cater for the common case of adding plural even for those options that don't make sense
+	// as it's quite common for those who English is not a first language to make a simple mistake
+	switch sortBy {
+	case "name", "names", "language", "languages", "lang", "langs":
+		return func(a, b []string) int {
+			return strings.Compare(a[0], b[0])
+		}
+	case "line", "lines":
+		return func(a, b []string) int {
+			i1, _ := strconv.ParseInt(a[1], 10, 64)
+			i2, _ := strconv.ParseInt(b[1], 10, 64)
+			return cmp.Compare(i2, i1)
+		}
+	case "blank", "blanks":
+		return func(a, b []string) int {
+			i1, _ := strconv.ParseInt(a[4], 10, 64)
+			i2, _ := strconv.ParseInt(b[4], 10, 64)
+			return cmp.Compare(i2, i1)
+		}
+	case "code", "codes":
+		return func(a, b []string) int {
+			i1, _ := strconv.ParseInt(a[2], 10, 64)
+			i2, _ := strconv.ParseInt(b[2], 10, 64)
+			return cmp.Compare(i2, i1)
+		}
+	case "comment", "comments":
+		return func(a, b []string) int {
+			i1, _ := strconv.ParseInt(a[3], 10, 64)
+			i2, _ := strconv.ParseInt(b[3], 10, 64)
+			return cmp.Compare(i2, i1)
+		}
+	case "complexity", "complexitys":
+		return func(a, b []string) int {
+			i1, _ := strconv.ParseInt(a[5], 10, 64)
+			i2, _ := strconv.ParseInt(b[5], 10, 64)
+			return cmp.Compare(i2, i1)
+		}
+	case "byte", "bytes":
+		return func(a, b []string) int {
+			i1, _ := strconv.ParseInt(a[6], 10, 64)
+			i2, _ := strconv.ParseInt(b[6], 10, 64)
+			return cmp.Compare(i2, i1)
+		}
+	case "file", "files":
+		return func(a, b []string) int {
+			i1, _ := strconv.ParseInt(a[7], 10, 64)
+			i2, _ := strconv.ParseInt(b[7], 10, 64)
+			return cmp.Compare(i2, i1)
+		}
+	default:
+		return func(a, b []string) int {
+			return strings.Compare(a[0], b[0])
+		}
+	}
+}
+
 func toCSVSummary(input chan *FileJob) string {
 	language := aggregateLanguageSummary(input)
-	language = sortLanguageSummary(language)
 
 	records := make([][]string, 0, len(language))
 
@@ -312,7 +368,7 @@ func toCSVSummary(input chan *FileJob) string {
 		})
 	}
 
-	slices.SortFunc(records, getRecordsSortFunc())
+	slices.SortFunc(records, getCSVSummarySortFunc(SortBy))
 
 	recordsEnd := [][]string{{
 		"Language",
@@ -336,10 +392,10 @@ func toCSVSummary(input chan *FileJob) string {
 	return b.String()
 }
 
-func getRecordsSortFunc() func(a, b []string) int {
+func getCSVFilesSortFunc(sortBy string) func(a, b []string) int {
 	// Cater for the common case of adding plural even for those options that don't make sense
 	// as it's quite common for those who English is not a first language to make a simple mistake
-	switch SortBy {
+	switch sortBy {
 	case "name", "names":
 		return func(a, b []string) int {
 			return strings.Compare(a[2], b[2])
@@ -409,7 +465,7 @@ func toCSVFiles(input chan *FileJob) string {
 		})
 	}
 
-	slices.SortFunc(records, getRecordsSortFunc())
+	slices.SortFunc(records, getCSVFilesSortFunc(SortBy))
 
 	recordsEnd := [][]string{{
 		"Language",

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -3,6 +3,7 @@
 package processor
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -1411,5 +1412,133 @@ func BenchmarkFileSummerize(b *testing.B) {
 		b.StartTimer()
 
 		fileSummarize(fileSummaryJobQueue)
+	}
+}
+
+func TestGetCSVSummarySortFunc(t *testing.T) {
+	records := [][]string{
+		// Language,Lines,Code,Comments,Blanks,Complexity,Bytes,Files,ULOC
+		{"Go", "10", "10", "0", "1", "1", "1024", "1", "0"},
+		{"Python", "20", "20", "1", "2", "2", "2048", "2", "0"},
+		{"C#", "30", "30", "2", "3", "3", "4096", "3", "0"},
+		{"C++", "40", "40", "3", "4", "4", "8192", "4", "0"},
+	}
+	testCases := []struct {
+		sortBy   string
+		expected []string
+	}{
+		{
+			sortBy:   "names",
+			expected: []string{"C#", "C++", "Go", "Python"},
+		},
+		{
+			sortBy:   "langs",
+			expected: []string{"C#", "C++", "Go", "Python"},
+		},
+		{
+			sortBy:   "lines",
+			expected: []string{"C++", "C#", "Python", "Go"},
+		},
+		{
+			sortBy:   "code",
+			expected: []string{"C++", "C#", "Python", "Go"},
+		},
+		{
+			sortBy:   "comments",
+			expected: []string{"C++", "C#", "Python", "Go"},
+		},
+		{
+			sortBy:   "blanks",
+			expected: []string{"C++", "C#", "Python", "Go"},
+		},
+		{
+			sortBy:   "complexity",
+			expected: []string{"C++", "C#", "Python", "Go"},
+		},
+		{
+			sortBy:   "bytes",
+			expected: []string{"C++", "C#", "Python", "Go"},
+		},
+		{
+			sortBy:   "files",
+			expected: []string{"C++", "C#", "Python", "Go"},
+		},
+		{
+			sortBy:   "default",
+			expected: []string{"C#", "C++", "Go", "Python"},
+		},
+	}
+	for _, tc := range testCases {
+		data := slices.Clone(records) // always use an unordered records
+		slices.SortFunc(data, getCSVSummarySortFunc(tc.sortBy))
+		sortedRecords := make([]string, 0, len(data))
+		for i := range data {
+			sortedRecords = append(sortedRecords, data[i][0])
+		}
+		if !slices.Equal(sortedRecords, tc.expected) {
+			t.Errorf("sortBy: %s failed, expected: %v, got: %v", tc.sortBy, tc.expected, sortedRecords)
+		}
+	}
+}
+
+func TestGetCSVFilesSortFunc(t *testing.T) {
+	records := [][]string{
+		// Language,Provider,Filename,Lines,Code,Comments,Blanks,Complexity,Bytes,ULOC
+		{"Go", "/path/to/file", "go.go", "10", "10", "0", "1", "1", "1024", "0"},
+		{"Python", "/path/to/file", "python.py", "20", "20", "1", "2", "2", "2048", "0"},
+		{"C#", "/path/to/file", "csharp.cs", "30", "30", "2", "3", "3", "4096", "0"},
+		{"C++", "/path/to/file", "cpp.cpp", "40", "40", "3", "4", "4", "8192", "0"},
+	}
+	testCases := []struct {
+		sortBy   string
+		expected []string
+	}{
+		{
+			sortBy:   "names",
+			expected: []string{"C++", "C#", "Go", "Python"},
+		},
+		{
+			sortBy:   "langs",
+			expected: []string{"C#", "C++", "Go", "Python"},
+		},
+		{
+			sortBy:   "lines",
+			expected: []string{"C++", "C#", "Python", "Go"},
+		},
+		{
+			sortBy:   "code",
+			expected: []string{"C++", "C#", "Python", "Go"},
+		},
+		{
+			sortBy:   "comments",
+			expected: []string{"C++", "C#", "Python", "Go"},
+		},
+		{
+			sortBy:   "blanks",
+			expected: []string{"C++", "C#", "Python", "Go"},
+		},
+		{
+			sortBy:   "complexity",
+			expected: []string{"C++", "C#", "Python", "Go"},
+		},
+		{
+			sortBy:   "bytes",
+			expected: []string{"C++", "C#", "Python", "Go"},
+		},
+		{
+			sortBy:   "default",
+			expected: []string{"C++", "C#", "Go", "Python"},
+		},
+	}
+	for _, tc := range testCases {
+		data := slices.Clone(records) // always use an unordered records
+		slices.SortFunc(data, getCSVFilesSortFunc(tc.sortBy))
+		sortedRecords := make([]string, 0, len(data))
+		for i := range data {
+			sortedRecords = append(sortedRecords, data[i][0])
+		}
+		if !slices.Equal(sortedRecords, tc.expected) {
+			t.Errorf("sortBy: %s failed, expected: %v, got: %v", tc.sortBy, tc.expected, sortedRecords)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #646.

"CSVSummary" and "CSVFiles" have different numbers and names of columns, so sharing `getRecordsSortFunc` caused this bug. I split them into different functions and added unit tests.

Also the call to `sortLanguageSummary` in "CSVSummary" is unnecessary because we always re-sort all records. So I removed it.