### PR TITLE
perf: speed up toCSVSummary

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>27</th>
-		<th>23110</th>
-		<th>1442</th>
-		<th>442</th>
-		<th>21226</th>
-		<th>1369</th>
-		<th>449731</th>
-		<th>6246</th>
+		<th>23053</th>
+		<th>1444</th>
+		<th>439</th>
+		<th>21170</th>
+		<th>1377</th>
+		<th>447469</th>
+		<th>6255</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
 		<td></td>
@@ -43,23 +43,23 @@
 	</tr><tr>
 		<td>processor/formatters_test.go</td>
 		<td></td>
-		<td>1544</td>
-		<td>148</td>
-		<td>5</td>
-		<td>1391</td>
-		<td>124</td>
-		<td>36647</td>
-		<td>400</td>
+		<td>1535</td>
+		<td>153</td>
+		<td>4</td>
+		<td>1378</td>
+		<td>129</td>
+		<td>35790</td>
+		<td>406</td>
 	</tr><tr>
 		<td>processor/formatters.go</td>
 		<td></td>
-		<td>1517</td>
-		<td>202</td>
-		<td>33</td>
-		<td>1282</td>
-		<td>153</td>
-		<td>45133</td>
-		<td>776</td>
+		<td>1469</td>
+		<td>199</td>
+		<td>31</td>
+		<td>1239</td>
+		<td>156</td>
+		<td>43728</td>
+		<td>779</td>
 	</tr><tr>
 		<td>processor/workers.go</td>
 		<td></td>
@@ -201,16 +201,6 @@
 		<td>2771</td>
 		<td>80</td>
 	</tr><tr>
-		<td>processor/trace.go</td>
-		<td></td>
-		<td>96</td>
-		<td>15</td>
-		<td>8</td>
-		<td>73</td>
-		<td>9</td>
-		<td>1957</td>
-		<td>58</td>
-	</tr><tr>
 		<td>processor/structs_test.go</td>
 		<td></td>
 		<td>96</td>
@@ -220,6 +210,16 @@
 		<td>10</td>
 		<td>1982</td>
 		<td>57</td>
+	</tr><tr>
+		<td>processor/trace.go</td>
+		<td></td>
+		<td>96</td>
+		<td>15</td>
+		<td>8</td>
+		<td>73</td>
+		<td>9</td>
+		<td>1957</td>
+		<td>58</td>
 	</tr><tr>
 		<td>scripts/include.go</td>
 		<td></td>
@@ -251,16 +251,6 @@
 		<td>2209</td>
 		<td>35</td>
 	</tr><tr>
-		<td>processor/bloom.go</td>
-		<td></td>
-		<td>37</td>
-		<td>7</td>
-		<td>12</td>
-		<td>18</td>
-		<td>2</td>
-		<td>1062</td>
-		<td>29</td>
-	</tr><tr>
 		<td>processor/cocomo_test.go</td>
 		<td></td>
 		<td>37</td>
@@ -270,6 +260,16 @@
 		<td>6</td>
 		<td>686</td>
 		<td>23</td>
+	</tr><tr>
+		<td>processor/bloom.go</td>
+		<td></td>
+		<td>37</td>
+		<td>7</td>
+		<td>12</td>
+		<td>18</td>
+		<td>2</td>
+		<td>1062</td>
+		<td>29</td>
 	</tr><tr>
 		<td>processor/helpers_test.go</td>
 		<td></td>
@@ -294,15 +294,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>27</th>
-		<th>23110</th>
-		<th>1442</th>
-		<th>442</th>
-		<th>21226</th>
-		<th>1369</th>
-		<th>449731</th>
-		<th>6246</th>
+		<th>23053</th>
+		<th>1444</th>
+		<th>439</th>
+		<th>21170</th>
+		<th>1377</th>
+		<th>447469</th>
+		<th>6255</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $668,046<br>Estimated Schedule Effort (organic) 11.80 months<br>Estimated People Required (organic) 5.03<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $666,196<br>Estimated Schedule Effort (organic) 11.79 months<br>Estimated People Required (organic) 5.02<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -311,6 +311,54 @@ func TestSortLanguageSummaryComplexity(t *testing.T) {
 	}
 }
 
+func TestSortLanguageSummaryBytes(t *testing.T) {
+	SortBy = "bytes"
+	ls := []LanguageSummary{
+		{
+			Name:  "a",
+			Bytes: 1,
+		},
+		{
+			Name:  "b",
+			Bytes: 1,
+		},
+		{
+			Name:  "c",
+			Bytes: 2,
+		},
+	}
+
+	ls = sortLanguageSummary(ls)
+
+	if ls[0].Name != "c" || ls[1].Name != "a" {
+		t.Error("Expected c to be first and a second")
+	}
+}
+
+func TestSortLanguageSummaryFiles(t *testing.T) {
+	SortBy = "files"
+	ls := []LanguageSummary{
+		{
+			Name:  "a",
+			Count: 1,
+		},
+		{
+			Name:  "b",
+			Count: 1,
+		},
+		{
+			Name:  "c",
+			Count: 2,
+		},
+	}
+
+	ls = sortLanguageSummary(ls)
+
+	if ls[0].Name != "c" || ls[1].Name != "a" {
+		t.Error("Expected c to be first and a second")
+	}
+}
+
 func TestSortSummaryNames(t *testing.T) {
 	SortBy = "name"
 	ls := []LanguageSummary{
@@ -1408,76 +1456,19 @@ func BenchmarkFileSummerize(b *testing.B) {
 			Language:   "Go",
 			Lines:      10,
 		}
+		fileSummaryJobQueue <- &FileJob{
+			Blank:      2,
+			Bytes:      2,
+			Code:       2,
+			Comment:    2,
+			Complexity: 2,
+			Language:   "Python",
+			Lines:      20,
+		}
 		close(fileSummaryJobQueue)
 		b.StartTimer()
 
 		fileSummarize(fileSummaryJobQueue)
-	}
-}
-
-func TestGetCSVSummarySortFunc(t *testing.T) {
-	records := [][]string{
-		// Language,Lines,Code,Comments,Blanks,Complexity,Bytes,Files,ULOC
-		{"Go", "10", "10", "0", "1", "1", "1024", "1", "0"},
-		{"Python", "20", "20", "1", "2", "2", "2048", "2", "0"},
-		{"C#", "30", "30", "2", "3", "3", "4096", "3", "0"},
-		{"C++", "40", "40", "3", "4", "4", "8192", "4", "0"},
-	}
-	testCases := []struct {
-		sortBy   string
-		expected []string
-	}{
-		{
-			sortBy:   "names",
-			expected: []string{"C#", "C++", "Go", "Python"},
-		},
-		{
-			sortBy:   "langs",
-			expected: []string{"C#", "C++", "Go", "Python"},
-		},
-		{
-			sortBy:   "lines",
-			expected: []string{"C++", "C#", "Python", "Go"},
-		},
-		{
-			sortBy:   "code",
-			expected: []string{"C++", "C#", "Python", "Go"},
-		},
-		{
-			sortBy:   "comments",
-			expected: []string{"C++", "C#", "Python", "Go"},
-		},
-		{
-			sortBy:   "blanks",
-			expected: []string{"C++", "C#", "Python", "Go"},
-		},
-		{
-			sortBy:   "complexity",
-			expected: []string{"C++", "C#", "Python", "Go"},
-		},
-		{
-			sortBy:   "bytes",
-			expected: []string{"C++", "C#", "Python", "Go"},
-		},
-		{
-			sortBy:   "files",
-			expected: []string{"C++", "C#", "Python", "Go"},
-		},
-		{
-			sortBy:   "default",
-			expected: []string{"C#", "C++", "Go", "Python"},
-		},
-	}
-	for _, tc := range testCases {
-		data := slices.Clone(records) // always use an unordered records
-		slices.SortFunc(data, getCSVSummarySortFunc(tc.sortBy))
-		sortedRecords := make([]string, 0, len(data))
-		for i := range data {
-			sortedRecords = append(sortedRecords, data[i][0])
-		}
-		if !slices.Equal(sortedRecords, tc.expected) {
-			t.Errorf("sortBy: %s failed, expected: %v, got: %v", tc.sortBy, tc.expected, sortedRecords)
-		}
 	}
 }
 


### PR DESCRIPTION
Optimizations:
- Sorting summaries is faster than sorting string arrays, so sorting summaries before serializing.
- Reusing memory reduces the performance overhead when serializing to CSV.

These optimizations can gain performance improvements:

```
goos: darwin
goarch: arm64
pkg: github.com/boyter/scc/v3/processor
cpu: Apple M4
                 │     old     │                 new                 │
                 │   sec/op    │   sec/op     vs base                │
FileSummerize-10   1.696µ ± 1%   1.467µ ± 6%  -13.51% (p=0.000 n=10)

                 │     old      │                 new                  │
                 │     B/op     │     B/op      vs base                │
FileSummerize-10   5.375Ki ± 0%   4.828Ki ± 0%  -10.17% (p=0.000 n=10)

                 │     old     │                new                 │
                 │  allocs/op  │ allocs/op   vs base                │
FileSummerize-10   12.000 ± 0%   7.000 ± 0%  -41.67% (p=0.000 n=10)
```

This is the case where only two languages are involved. The more languages included in the result, the larger the improvement achieved.