### PR TITLE
fix: Remove ComplexityLine from JSON output

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>27</th>
-		<th>23053</th>
-		<th>1444</th>
+		<th>23102</th>
+		<th>1447</th>
 		<th>439</th>
-		<th>21170</th>
-		<th>1377</th>
-		<th>447469</th>
-		<th>6255</th>
+		<th>21216</th>
+		<th>1383</th>
+		<th>448821</th>
+		<th>6291</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
 		<td></td>
@@ -158,7 +158,7 @@
 		<td>18</td>
 		<td>163</td>
 		<td>17</td>
-		<td>6061</td>
+		<td>6072</td>
 		<td>142</td>
 	</tr><tr>
 		<td>cmd/badges/main_test.go</td>
@@ -191,6 +191,16 @@
 		<td>2573</td>
 		<td>66</td>
 	</tr><tr>
+		<td>processor/structs_test.go</td>
+		<td></td>
+		<td>145</td>
+		<td>14</td>
+		<td>1</td>
+		<td>130</td>
+		<td>16</td>
+		<td>3323</td>
+		<td>96</td>
+	</tr><tr>
 		<td>processor/trace_test.go</td>
 		<td></td>
 		<td>117</td>
@@ -200,16 +210,6 @@
 		<td>15</td>
 		<td>2771</td>
 		<td>80</td>
-	</tr><tr>
-		<td>processor/structs_test.go</td>
-		<td></td>
-		<td>96</td>
-		<td>11</td>
-		<td>1</td>
-		<td>84</td>
-		<td>10</td>
-		<td>1982</td>
-		<td>57</td>
 	</tr><tr>
 		<td>processor/trace.go</td>
 		<td></td>
@@ -251,16 +251,6 @@
 		<td>2209</td>
 		<td>35</td>
 	</tr><tr>
-		<td>processor/cocomo_test.go</td>
-		<td></td>
-		<td>37</td>
-		<td>8</td>
-		<td>4</td>
-		<td>25</td>
-		<td>6</td>
-		<td>686</td>
-		<td>23</td>
-	</tr><tr>
 		<td>processor/bloom.go</td>
 		<td></td>
 		<td>37</td>
@@ -270,6 +260,16 @@
 		<td>2</td>
 		<td>1062</td>
 		<td>29</td>
+	</tr><tr>
+		<td>processor/cocomo_test.go</td>
+		<td></td>
+		<td>37</td>
+		<td>8</td>
+		<td>4</td>
+		<td>25</td>
+		<td>6</td>
+		<td>686</td>
+		<td>23</td>
 	</tr><tr>
 		<td>processor/helpers_test.go</td>
 		<td></td>
@@ -294,15 +294,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>27</th>
-		<th>23053</th>
-		<th>1444</th>
+		<th>23102</th>
+		<th>1447</th>
 		<th>439</th>
-		<th>21170</th>
-		<th>1377</th>
-		<th>447469</th>
-		<th>6255</th>
+		<th>21216</th>
+		<th>1383</th>
+		<th>448821</th>
+		<th>6291</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $666,196<br>Estimated Schedule Effort (organic) 11.79 months<br>Estimated People Required (organic) 5.02<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $667,716<br>Estimated Schedule Effort (organic) 11.80 months<br>Estimated People Required (organic) 5.03<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/processor/structs.go
+++ b/processor/structs.go
@@ -30,13 +30,13 @@ type Language struct {
 	LineComment      []string   `json:"line_comment"`
 	ComplexityChecks []string   `json:"complexitychecks"`
 	Extensions       []string   `json:"extensions"`
-	ExtensionFile    bool       `json:"extensionFile"`
 	MultiLine        [][]string `json:"multi_line"`
 	Quotes           []Quote    `json:"quotes"`
-	NestedMultiLine  bool       `json:"nestedmultiline"`
 	Keywords         []string   `json:"keywords"`
 	FileNames        []string   `json:"filenames"`
 	SheBangs         []string   `json:"shebangs"`
+	ExtensionFile    bool       `json:"extensionFile"`
+	NestedMultiLine  bool       `json:"nestedmultiline"`
 }
 
 // LanguageFeature is a struct which represents the conversion from Language into what is used for matching
@@ -79,7 +79,7 @@ type FileJob struct {
 	Comment            int64
 	Blank              int64
 	Complexity         int64
-	ComplexityLine     []int64
+	ComplexityLine     []int64 `json:"-"`
 	WeightedComplexity float64
 	Hash               hash.Hash
 	Callback           FileJobCallback `json:"-"`

--- a/processor/structs_test.go
+++ b/processor/structs_test.go
@@ -3,7 +3,9 @@
 package processor
 
 import (
+	"encoding/json"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -92,5 +94,52 @@ func TestMatch(t *testing.T) {
 		if !slices.Equal(tc.expectClosed, closed) {
 			t.Errorf("\"%v\" matched wrong closed, want: %v, got: %v", string(tc.token), tc.expectClosed, closed)
 		}
+	}
+}
+
+func TestFileJobJSONIgnoreFields(t *testing.T) {
+	job := FileJob{
+		Language:           "Dockerfile",
+		PossibleLanguages:  []string{"Dockerfile"},
+		Filename:           "Dockerfile",
+		Extension:          "Dockerfile",
+		Location:           "Dockerfile",
+		Symlocation:        "",
+		Content:            []uint8{1, 2, 3},
+		Bytes:              248,
+		Lines:              14,
+		Code:               11,
+		Comment:            0,
+		Blank:              3,
+		Complexity:         1,
+		ComplexityLine:     []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		WeightedComplexity: 1,
+		Hash:               nil,
+		Callback:           &linecounter{},
+		Binary:             false,
+		Minified:           false,
+		Generated:          false,
+		EndPoint:           0,
+		Uloc:               0,
+		LineLength:         []int{1, 2, 3},
+	}
+
+	data, err := json.MarshalIndent(&job, "", "\t")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jsonStr := string(data)
+	if strings.Contains(jsonStr, `"Content": `) {
+		t.Errorf("Content should be ignored")
+	}
+	if strings.Contains(jsonStr, `"ComplexityLine": `) {
+		t.Errorf("ComplexityLine should be ignored")
+	}
+	if strings.Contains(jsonStr, `"Callback": `) {
+		t.Errorf("Callback should be ignored")
+	}
+	if strings.Contains(jsonStr, `"LineLength": `) {
+		t.Errorf("LineLength should be ignored")
 	}
 }


### PR DESCRIPTION
Fixes #645

Reduce `Language` size from 208 to 200 bytes by reordering fields. This can save some memory since we already have 350+ languages.