### PR TITLE
refactor: testing formatting using Go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,3 +23,6 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name: Test Race
+      run: go test -race -v ./...

--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>27</th>
-		<th>23152</th>
-		<th>1447</th>
+		<th>23414</th>
+		<th>1456</th>
 		<th>439</th>
-		<th>21266</th>
-		<th>1383</th>
-		<th>449516</th>
-		<th>6306</th>
+		<th>21519</th>
+		<th>1423</th>
+		<th>456460</th>
+		<th>6380</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
 		<td></td>
@@ -31,6 +31,16 @@
 		<td>211234</td>
 		<td>2066</td>
 	</tr><tr>
+		<td>processor/formatters_test.go</td>
+		<td></td>
+		<td>1797</td>
+		<td>162</td>
+		<td>4</td>
+		<td>1631</td>
+		<td>169</td>
+		<td>42734</td>
+		<td>486</td>
+	</tr><tr>
 		<td>processor/workers_test.go</td>
 		<td></td>
 		<td>1586</td>
@@ -40,16 +50,6 @@
 		<td>287</td>
 		<td>32293</td>
 		<td>525</td>
-	</tr><tr>
-		<td>processor/formatters_test.go</td>
-		<td></td>
-		<td>1535</td>
-		<td>153</td>
-		<td>4</td>
-		<td>1378</td>
-		<td>129</td>
-		<td>35790</td>
-		<td>406</td>
 	</tr><tr>
 		<td>processor/formatters.go</td>
 		<td></td>
@@ -294,15 +294,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>27</th>
-		<th>23152</th>
-		<th>1447</th>
+		<th>23414</th>
+		<th>1456</th>
 		<th>439</th>
-		<th>21266</th>
-		<th>1383</th>
-		<th>449516</th>
-		<th>6306</th>
+		<th>21519</th>
+		<th>1423</th>
+		<th>456460</th>
+		<th>6380</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $669,368<br>Estimated Schedule Effort (organic) 11.81 months<br>Estimated People Required (organic) 5.04<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $677,732<br>Estimated Schedule Effort (organic) 11.86 months<br>Estimated People Required (organic) 5.08<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/test-all.sh
+++ b/test-all.sh
@@ -614,53 +614,8 @@ else
     exit
 fi
 
-if ./scc -f csv | grep -q "Bytes"; then
-    echo -e "${GREEN}PASSED csv bytes check"
-else
-    echo -e "${RED}======================================================="
-    echo -e "FAILED csv bytes check"
-    echo -e "=======================================================${NC}"
-    exit
-fi
-
-if ./scc -f csv-stream | grep -q "Bytes"; then
-    echo -e "${GREEN}PASSED csv-stream bytes check"
-else
-    echo -e "${RED}======================================================="
-    echo -e "FAILED csv-stream bytes check"
-    echo -e "=======================================================${NC}"
-    exit
-fi
-
-if ./scc -f html | grep -q "Bytes"; then
-    echo -e "${GREEN}PASSED html bytes check"
-else
-    echo -e "${RED}======================================================="
-    echo -e "FAILED html bytes check"
-    echo -e "=======================================================${NC}"
-    exit
-fi
-
 if ./scc -f json | grep -q "Bytes"; then
     echo -e "${GREEN}PASSED json bytes check"
-else
-    echo -e "${RED}======================================================="
-    echo -e "FAILED json bytes check"
-    echo -e "=======================================================${NC}"
-    exit
-fi
-
-if ./scc -f json  -a | grep -q "ULOC"; then
-    echo -e "${GREEN}PASSED json uloc check"
-else
-    echo -e "${RED}======================================================="
-    echo -e "FAILED json uloc check"
-    echo -e "=======================================================${NC}"
-    exit
-fi
-
-if ./scc -f json2 | grep -q "Bytes"; then
-    echo -e "${GREEN}PASSED json2 bytes check"
 else
     echo -e "${RED}======================================================="
     echo -e "FAILED json bytes check"
@@ -673,24 +628,6 @@ if ./scc | grep -q "megabytes"; then
 else
     echo -e "${RED}======================================================="
     echo -e "FAILED bytes check"
-    echo -e "=======================================================${NC}"
-    exit
-fi
-
-if ./scc -f csv | grep -q "Language,Lines,Code,Comments,Blanks,Complexity,Bytes,Files,ULOC"; then
-    echo -e "${GREEN}PASSED csv summary"
-else
-    echo -e "${RED}======================================================="
-    echo -e "FAILED csv summary"
-    echo -e "=======================================================${NC}"
-    exit
-fi
-
-if ./scc -f csv --by-file | grep -q "Language,Provider,Filename,Lines,Code,Comments,Blanks,Complexity,Bytes"; then
-    echo -e "${GREEN}PASSED csv file"
-else
-    echo -e "${RED}======================================================="
-    echo -e "FAILED csv file"
     echo -e "=======================================================${NC}"
     exit
 fi


### PR DESCRIPTION
Convert some tests from Bash to Go. Go enables more precise result verification.

This should also benefit another pull request to remove test-all.sh.

Additionally, adding race tests to CI generally provides more opportunities to find concurrency issues.