### PR TITLE
feat: Automatically provide corrective suggestions when command-line …

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -12,14 +12,14 @@
 	</tr></thead>
 	<tbody><tr>
 		<th>Go</th>
-		<th>27</th>
-		<th>23501</th>
-		<th>1456</th>
-		<th>439</th>
-		<th>21606</th>
-		<th>1423</th>
-		<th>457896</th>
-		<th>6406</th>
+		<th>29</th>
+		<th>23721</th>
+		<th>1471</th>
+		<th>452</th>
+		<th>21798</th>
+		<th>1442</th>
+		<th>462788</th>
+		<th>6497</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
 		<td></td>
@@ -81,6 +81,16 @@
 		<td>18249</td>
 		<td>416</td>
 	</tr><tr>
+		<td>main.go</td>
+		<td></td>
+		<td>481</td>
+		<td>15</td>
+		<td>9</td>
+		<td>457</td>
+		<td>24</td>
+		<td>11384</td>
+		<td>304</td>
+	</tr><tr>
 		<td>cmd/badges/main.go</td>
 		<td></td>
 		<td>468</td>
@@ -90,16 +100,6 @@
 		<td>68</td>
 		<td>12982</td>
 		<td>297</td>
-	</tr><tr>
-		<td>main.go</td>
-		<td></td>
-		<td>459</td>
-		<td>12</td>
-		<td>8</td>
-		<td>439</td>
-		<td>17</td>
-		<td>10587</td>
-		<td>291</td>
 	</tr><tr>
 		<td>processor/detector_test.go</td>
 		<td></td>
@@ -201,6 +201,16 @@
 		<td>3323</td>
 		<td>96</td>
 	</tr><tr>
+		<td>processor/similar_flags_test.go</td>
+		<td></td>
+		<td>132</td>
+		<td>5</td>
+		<td>0</td>
+		<td>127</td>
+		<td>5</td>
+		<td>2333</td>
+		<td>58</td>
+	</tr><tr>
 		<td>processor/trace_test.go</td>
 		<td></td>
 		<td>117</td>
@@ -230,6 +240,16 @@
 		<td>19</td>
 		<td>2140</td>
 		<td>64</td>
+	</tr><tr>
+		<td>processor/similar_flags.go</td>
+		<td></td>
+		<td>66</td>
+		<td>7</td>
+		<td>12</td>
+		<td>47</td>
+		<td>7</td>
+		<td>1762</td>
+		<td>51</td>
 	</tr><tr>
 		<td>processor/filereader.go</td>
 		<td></td>
@@ -293,16 +313,16 @@
 	</tr></tbody>
 	<tfoot><tr>
 		<th>Total</th>
-		<th>27</th>
-		<th>23501</th>
-		<th>1456</th>
-		<th>439</th>
-		<th>21606</th>
-		<th>1423</th>
-		<th>457896</th>
-		<th>6406</th>
+		<th>29</th>
+		<th>23721</th>
+		<th>1471</th>
+		<th>452</th>
+		<th>21798</th>
+		<th>1442</th>
+		<th>462788</th>
+		<th>6497</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $680,610<br>Estimated Schedule Effort (organic) 11.88 months<br>Estimated People Required (organic) 5.09<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $686,962<br>Estimated Schedule Effort (organic) 11.92 months<br>Estimated People Required (organic) 5.12<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module github.com/boyter/scc/v3
 go 1.25.2
 
 require (
+	github.com/agnivade/levenshtein v1.2.2-0.20250519083737-420867539855
 	github.com/boyter/gocodewalker v1.5.1
 	github.com/boyter/simplecache v0.0.0-20250113230110-8a4c9201822a
 	github.com/json-iterator/go v1.1.12
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/rs/zerolog v1.30.0
 	github.com/spf13/cobra v1.10.1
+	github.com/spf13/pflag v1.0.10
 	golang.org/x/crypto v0.43.0
 	golang.org/x/text v0.30.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -22,7 +24,6 @@ require (
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/agnivade/levenshtein v1.2.2-0.20250519083737-420867539855 h1:eecTPiTbYU25fX1PZ2euFs9ol/TwQsJbRZwOF6pddw8=
+github.com/agnivade/levenshtein v1.2.2-0.20250519083737-420867539855/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/boyter/gocodewalker v1.5.1 h1:0YeK2QAkd+ymW5MsagMZapIXD3v9/vrZl0HkFSLpKsw=
 github.com/boyter/gocodewalker v1.5.1/go.mod h1:9k+yM6+fIx61F0xI9ChXEGE5DYoLhggw8AxSOtW+kKo=
 github.com/boyter/simplecache v0.0.0-20250113230110-8a4c9201822a h1:eL28tNqB4nBuMVA+WijpviMStOY7NAFWDowPB6I6Ruo=
@@ -11,6 +15,8 @@ github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
+github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/processor/similar_flags.go
+++ b/processor/similar_flags.go
@@ -1,0 +1,66 @@
+package processor
+
+import (
+	"cmp"
+	"slices"
+	"strings"
+
+	"github.com/agnivade/levenshtein"
+	"github.com/spf13/pflag"
+)
+
+const SimilarStringThreshold float64 = 0.8
+
+// StringSimilarRatio calculates the similarity ratio between s1 and s2.
+//
+// The function is based on the Levenshtein distance. The ratio is calculated using the formula:
+//
+// 1 - (Levenshtein Distance / length of the longer string).
+//
+// It returns a float64 between 0.0 (completely dissimilar) and 1.0 (identical).
+// Based on experience, a ratio >= [SimilarStringThreshold] can generally be
+// considered to indicate that two strings are highly similar.
+//
+// Note: The comparison is case-sensitive. For example, "hello" and "HELLO"
+// will be treated as completely different strings (their similarity ratio is 0).
+func StringSimilarRatio(s1, s2 string) float64 {
+	distance := levenshtein.ComputeDistance(s1, s2)
+	return 1 - float64(distance)/float64(max(len(s1), len(s2)))
+}
+
+type similarFlag struct {
+	name  string
+	ratio float64
+}
+
+func GetMostSimilarFlags(flagSet *pflag.FlagSet, flag string) []string {
+	similarFlags := make([]similarFlag, 0)
+	flagSet.VisitAll(func(f *pflag.Flag) {
+		if len(f.Name) <= 1 {
+			return
+		}
+		ratio := StringSimilarRatio(flag, f.Name)
+		if ratio >= SimilarStringThreshold {
+			similarFlags = append(similarFlags, similarFlag{
+				name:  f.Name,
+				ratio: ratio,
+			})
+		}
+	})
+	if len(similarFlags) == 0 {
+		return []string{}
+	}
+
+	slices.SortFunc(similarFlags, func(a, b similarFlag) int {
+		result := cmp.Compare(b.ratio, a.ratio)
+		if result != 0 {
+			return result
+		}
+		return strings.Compare(a.name, b.name)
+	})
+	result := make([]string, 0, len(similarFlags))
+	for _, sc := range similarFlags {
+		result = append(result, sc.name)
+	}
+	return result
+}

--- a/processor/similar_flags_test.go
+++ b/processor/similar_flags_test.go
@@ -1,0 +1,132 @@
+package processor
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestStringSimilarRatio(t *testing.T) {
+	testCases := []struct {
+		s1, s2    string
+		isSimilar bool
+	}{
+		{
+			s1:        "",
+			s2:        "",
+			isSimilar: false,
+		},
+		{
+			s1:        "",
+			s2:        "hello",
+			isSimilar: false,
+		},
+		{
+			s1:        "hello",
+			s2:        "",
+			isSimilar: false,
+		},
+		{
+			s1:        "hello",
+			s2:        "hello",
+			isSimilar: true,
+		},
+		{
+			s1:        "hello",
+			s2:        "Hello",
+			isSimilar: true,
+		},
+		{
+			s1:        "hello",
+			s2:        "helle",
+			isSimilar: true,
+		},
+		{
+			s1:        "hello",
+			s2:        "hallo",
+			isSimilar: true,
+		},
+		{
+			s1:        "hello",
+			s2:        "helo",
+			isSimilar: true,
+		},
+		{
+			s1:        "hello",
+			s2:        "hell",
+			isSimilar: true,
+		},
+		{
+			s1:        "hello",
+			s2:        "heelo",
+			isSimilar: true,
+		},
+		{
+			s1:        "hello",
+			s2:        "hello-world",
+			isSimilar: false,
+		},
+		{
+			s1:        "hello",
+			s2:        "how",
+			isSimilar: false,
+		},
+		{
+			s1:        "hello",
+			s2:        "HELLO",
+			isSimilar: false,
+		},
+		{
+			s1:        "python",
+			s2:        "golang",
+			isSimilar: false,
+		},
+	}
+	for _, tc := range testCases {
+		result := StringSimilarRatio(tc.s1, tc.s2) >= SimilarStringThreshold
+		if result != tc.isSimilar {
+			t.Errorf("StringSimilarRatio(%q, %q) failed, got %v, want %v", tc.s1, tc.s2, result, tc.isSimilar)
+		}
+	}
+}
+
+func TestGetMostSimilarFlags(t *testing.T) {
+	flags := pflag.NewFlagSet("testing", pflag.ExitOnError)
+	_ = flags.Bool("no-ignore", false, "test")
+	_ = flags.Bool("no-gitignore", false, "test")
+	_ = flags.Int("no-gitmodule", 0, "test")
+	_ = flags.String("format", "", "test")
+
+	testCases := []struct {
+		name    string
+		expects []string
+	}{
+		{
+			name:    "",
+			expects: []string{},
+		},
+		{
+			name:    "unknown",
+			expects: []string{},
+		},
+		{
+			name:    "no-gignore",
+			expects: []string{"no-ignore", "no-gitignore"},
+		},
+		{
+			name:    "no-gitmodyle",
+			expects: []string{"no-gitmodule"},
+		},
+		{
+			name:    "formet",
+			expects: []string{"format"},
+		},
+	}
+	for _, tc := range testCases {
+		result := GetMostSimilarFlags(flags, tc.name)
+		if !slices.Equal(result, tc.expects) {
+			t.Errorf("got: %v, want: %v", result, tc.expects)
+		}
+	}
+}

--- a/test-all.sh
+++ b/test-all.sh
@@ -879,7 +879,7 @@ specificLanguages=(
     'Clojure '
     'CMake '
     'Cuda '
-    'Cypher'
+    'Cypher '
     'DAML '
     'DM '
     'Docker ignore '
@@ -1148,6 +1148,30 @@ do
         exit
     fi
 done
+
+if [[ "$(./scc --farmat 2>&1 | grep -A 1 'The most similar flag of --farmat is:' | tail -n 1)" == $'\t--format' ]]; then
+    echo -e "${GREEN}PASSED signle flag suggestion test"
+else
+    echo -e "${RED}======================================================="
+    echo -e "FAILED Should suggest --format $i"
+    echo -e "=======================================================${NC}"
+    exit
+fi
+if [[ "$(./scc --no-gignore 2>&1 | grep -A 2 'The most similar flags of --no-gignore are:' | tail -n 2 | head -n 1)" == $'\t--no-ignore' ]]; then
+    if [[ "$(./scc --no-gignore 2>&1 | grep -A 2 'The most similar flags of --no-gignore are:' | tail -n 1)" == $'\t--no-gitignore' ]]; then
+        echo -e "${GREEN}PASSED multiple flags suggestion test"
+    else
+        echo -e "${RED}======================================================="
+        echo -e "FAILED Should suggest --no-gitignore $i"
+        echo -e "=======================================================${NC}"
+        exit
+    fi
+else
+    echo -e "${RED}======================================================="
+    echo -e "FAILED Should suggest --no-ignore $i"
+    echo -e "=======================================================${NC}"
+    exit
+fi
 
 echo -e  "${NC}Checking compile targets..."
 

--- a/vendor/github.com/agnivade/levenshtein/.gitignore
+++ b/vendor/github.com/agnivade/levenshtein/.gitignore
@@ -1,0 +1,5 @@
+coverage.txt
+fuzz/fuzz-fuzz.zip
+fuzz/corpus/corpus/*
+fuzz/corpus/suppressions/*
+fuzz/corpus/crashes/*

--- a/vendor/github.com/agnivade/levenshtein/License.txt
+++ b/vendor/github.com/agnivade/levenshtein/License.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Agniva De Sarker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/agnivade/levenshtein/Makefile
+++ b/vendor/github.com/agnivade/levenshtein/Makefile
@@ -1,0 +1,13 @@
+all: test install
+
+install:
+	go install
+
+lint:
+	gofmt -l -s -w . && go vet .
+
+test:
+	go test -race -v -coverprofile=coverage.txt -covermode=atomic
+
+bench:
+	go test -run=XXX -bench=. -benchmem -count=5

--- a/vendor/github.com/agnivade/levenshtein/README.md
+++ b/vendor/github.com/agnivade/levenshtein/README.md
@@ -1,0 +1,80 @@
+levenshtein ![Build Status](https://github.com/agnivade/levenshtein/actions/workflows/ci.yml/badge.svg) [![Go Report Card](https://goreportcard.com/badge/github.com/agnivade/levenshtein)](https://goreportcard.com/report/github.com/agnivade/levenshtein) [![PkgGoDev](https://pkg.go.dev/badge/github.com/agnivade/levenshtein)](https://pkg.go.dev/github.com/agnivade/levenshtein)
+===========
+
+[Go](http://golang.org) package to calculate the [Levenshtein Distance](http://en.wikipedia.org/wiki/Levenshtein_distance)
+
+The library is fully capable of working with non-ascii strings. But the strings are not normalized. That is left as a user-dependant use case. Please normalize the strings before passing it to the library if you have such a requirement.
+- https://blog.golang.org/normalization
+
+#### Limitation
+
+As a performance optimization, the library can handle strings only up to 65536 characters (runes). If you need to handle strings larger than that, please pin to version 1.0.3.
+
+Install
+-------
+
+    go get github.com/agnivade/levenshtein
+
+Example
+-------
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/agnivade/levenshtein"
+)
+
+func main() {
+	s1 := "kitten"
+	s2 := "sitting"
+	distance := levenshtein.ComputeDistance(s1, s2)
+	fmt.Printf("The distance between %s and %s is %d.\n", s1, s2, distance)
+	// Output:
+	// The distance between kitten and sitting is 3.
+}
+
+```
+
+Benchmarks
+----------
+
+```
+name              time/op
+Simple/ASCII-4     330ns ± 2%
+Simple/French-4    617ns ± 2%
+Simple/Nordic-4   1.16µs ± 4%
+Simple/Tibetan-4  1.05µs ± 1%
+
+name              alloc/op
+Simple/ASCII-4     96.0B ± 0%
+Simple/French-4     128B ± 0%
+Simple/Nordic-4     192B ± 0%
+Simple/Tibetan-4    144B ± 0%
+
+name              allocs/op
+Simple/ASCII-4      1.00 ± 0%
+Simple/French-4     1.00 ± 0%
+Simple/Nordic-4     1.00 ± 0%
+Simple/Tibetan-4    1.00 ± 0%
+```
+
+Comparisons with other libraries
+--------------------------------
+
+```
+name                     time/op
+Leven/ASCII/agniva-4      353ns ± 1%
+Leven/ASCII/arbovm-4      485ns ± 1%
+Leven/ASCII/dgryski-4     395ns ± 0%
+Leven/French/agniva-4     648ns ± 1%
+Leven/French/arbovm-4     791ns ± 0%
+Leven/French/dgryski-4    682ns ± 0%
+Leven/Nordic/agniva-4    1.28µs ± 1%
+Leven/Nordic/arbovm-4    1.52µs ± 1%
+Leven/Nordic/dgryski-4   1.32µs ± 1%
+Leven/Tibetan/agniva-4   1.12µs ± 1%
+Leven/Tibetan/arbovm-4   1.31µs ± 0%
+Leven/Tibetan/dgryski-4  1.16µs ± 0%
+```

--- a/vendor/github.com/agnivade/levenshtein/levenshtein.go
+++ b/vendor/github.com/agnivade/levenshtein/levenshtein.go
@@ -1,0 +1,110 @@
+// Package levenshtein is a Go implementation to calculate Levenshtein Distance.
+//
+// Implementation taken from
+// https://gist.github.com/andrei-m/982927#gistcomment-1931258
+package levenshtein
+
+import "unicode/utf8"
+
+// minLengthThreshold is the length of the string beyond which
+// an allocation will be made. Strings smaller than this will be
+// zero alloc.
+const minLengthThreshold = 32
+
+// ComputeDistance computes the levenshtein distance between the two
+// strings passed as an argument. The return value is the levenshtein distance
+//
+// Works on runes (Unicode code points) but does not normalize
+// the input strings. See https://blog.golang.org/normalization
+// and the golang.org/x/text/unicode/norm package.
+func ComputeDistance(a, b string) int {
+	if len(a) == 0 {
+		return utf8.RuneCountInString(b)
+	}
+
+	if len(b) == 0 {
+		return utf8.RuneCountInString(a)
+	}
+
+	if a == b {
+		return 0
+	}
+
+	// We need to convert to []rune if the strings are non-ASCII.
+	// This could be avoided by using utf8.RuneCountInString
+	// and then doing some juggling with rune indices,
+	// but leads to far more bounds checks. It is a reasonable trade-off.
+	s1 := []rune(a)
+	s2 := []rune(b)
+
+	// swap to save some memory O(min(a,b)) instead of O(a)
+	if len(s1) > len(s2) {
+		s1, s2 = s2, s1
+	}
+
+	// remove trailing identical runes.
+	s1, s2 = trimLongestCommonSuffix(s1, s2)
+
+	// Remove leading identical runes.
+	s1, s2 = trimLongestCommonPrefix(s1, s2)
+
+	lenS1 := len(s1)
+	lenS2 := len(s2)
+
+	// Init the row.
+	var x []uint16
+	if lenS1+1 > minLengthThreshold {
+		x = make([]uint16, lenS1+1)
+	} else {
+		// We make a small optimization here for small strings.
+		// Because a slice of constant length is effectively an array,
+		// it does not allocate. So we can re-slice it to the right length
+		// as long as it is below a desired threshold.
+		x = make([]uint16, minLengthThreshold)
+		x = x[:lenS1+1]
+	}
+
+	// we start from 1 because index 0 is already 0.
+	for i := 1; i < len(x); i++ {
+		x[i] = uint16(i)
+	}
+
+	// hoist bounds checks out of the loops
+	_ = x[lenS1]
+	y := x[1:]
+	y = y[:lenS1]
+	// fill in the rest
+	for i := 0; i < lenS2; i++ {
+		prev := uint16(i + 1)
+		for j := 0; j < lenS1; j++ {
+			current := x[j] // match
+			if s2[i] != s1[j] {
+				current = min(x[j], prev, y[j]) + 1
+			}
+			x[j] = prev
+			prev = current
+		}
+		x[lenS1] = prev
+	}
+	return int(x[lenS1])
+}
+
+func trimLongestCommonSuffix(a, b []rune) ([]rune, []rune) {
+	m := min(len(a), len(b))
+	a2 := a[len(a)-m:]
+	b2 := b[len(b)-m:]
+	i := len(a2)
+	b2 = b2[:i] // hoist bounds checks out of the loop
+	for ; i > 0 && a2[i-1] == b2[i-1]; i-- {
+		// deliberately empty body
+	}
+	return a[:len(a)-len(a2)+i], b[:len(b)-len(b2)+i]
+}
+
+func trimLongestCommonPrefix(a, b []rune) ([]rune, []rune) {
+	var i int
+	for m := min(len(a), len(b)); i < m && a[i] == b[i]; i++ {
+		// deliberately empty body
+	}
+	return a[i:], b[i:]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,6 @@
+# github.com/agnivade/levenshtein v1.2.2-0.20250519083737-420867539855
+## explicit; go 1.21
+github.com/agnivade/levenshtein
 # github.com/boyter/gocodewalker v1.5.1
 ## explicit; go 1.23.0
 github.com/boyter/gocodewalker


### PR DESCRIPTION
…flags contain errors

Long command-line options are prone to typos, so the Levenshtein algorithm (An algorithm that determines how many edits are required to transform string a into string b, enabling estimation of similarity between strings.) can be used to provide some correction suggestions:

<img width="609" height="497" alt="image" src="https://github.com/user-attachments/assets/80fc7a40-40ee-4a16-8d89-299f63496d39" />

<img width="585" height="502" alt="image" src="https://github.com/user-attachments/assets/461bfee8-977c-4e38-b7e6-c97ec5b21d27" />

If no matching flags are found, nothing will be printed. Errors in short options do not trigger lookups, since similarity between single characters is meaningless.