### PR TITLE
feat: improve GetMostSimilarFlags

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>29</th>
-		<th>23737</th>
-		<th>1471</th>
-		<th>452</th>
-		<th>21814</th>
-		<th>1442</th>
-		<th>463117</th>
-		<th>6499</th>
+		<th>23804</th>
+		<th>1473</th>
+		<th>455</th>
+		<th>21876</th>
+		<th>1446</th>
+		<th>464520</th>
+		<th>6533</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
 		<td></td>
@@ -78,7 +78,7 @@
 		<td>103</td>
 		<td>389</td>
 		<td>79</td>
-		<td>18249</td>
+		<td>18242</td>
 		<td>416</td>
 	</tr><tr>
 		<td>main.go</td>
@@ -171,6 +171,16 @@
 		<td>4088</td>
 		<td>106</td>
 	</tr><tr>
+		<td>processor/similar_flags_test.go</td>
+		<td></td>
+		<td>176</td>
+		<td>5</td>
+		<td>1</td>
+		<td>170</td>
+		<td>5</td>
+		<td>3105</td>
+		<td>78</td>
+	</tr><tr>
 		<td>processor/file.go</td>
 		<td></td>
 		<td>153</td>
@@ -200,16 +210,6 @@
 		<td>16</td>
 		<td>3323</td>
 		<td>96</td>
-	</tr><tr>
-		<td>processor/similar_flags_test.go</td>
-		<td></td>
-		<td>132</td>
-		<td>5</td>
-		<td>0</td>
-		<td>127</td>
-		<td>5</td>
-		<td>2333</td>
-		<td>58</td>
 	</tr><tr>
 		<td>processor/trace_test.go</td>
 		<td></td>
@@ -243,13 +243,13 @@
 	</tr><tr>
 		<td>processor/similar_flags.go</td>
 		<td></td>
+		<td>89</td>
+		<td>9</td>
+		<td>14</td>
 		<td>66</td>
-		<td>7</td>
-		<td>12</td>
-		<td>47</td>
-		<td>7</td>
-		<td>1762</td>
-		<td>51</td>
+		<td>11</td>
+		<td>2400</td>
+		<td>67</td>
 	</tr><tr>
 		<td>processor/filereader.go</td>
 		<td></td>
@@ -314,15 +314,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>29</th>
-		<th>23737</th>
-		<th>1471</th>
-		<th>452</th>
-		<th>21814</th>
-		<th>1442</th>
-		<th>463117</th>
-		<th>6499</th>
+		<th>23804</th>
+		<th>1473</th>
+		<th>455</th>
+		<th>21876</th>
+		<th>1446</th>
+		<th>464520</th>
+		<th>6533</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $687,491<br>Estimated Schedule Effort (organic) 11.93 months<br>Estimated People Required (organic) 5.12<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $689,543<br>Estimated Schedule Effort (organic) 11.94 months<br>Estimated People Required (organic) 5.13<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/processor/similar_flags.go
+++ b/processor/similar_flags.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const SimilarStringThreshold float64 = 0.8
+const SimilarStringThreshold float64 = 0.75
 
 // StringSimilarRatio calculates the similarity ratio between s1 and s2.
 //
@@ -39,7 +39,12 @@ func GetMostSimilarFlags(flagSet *pflag.FlagSet, flag string) []string {
 		if len(f.Name) <= 1 {
 			return
 		}
-		ratio := StringSimilarRatio(flag, f.Name)
+		var ratio float64
+		if len(f.Name) <= 3 {
+			ratio = StringSimilarRatio("--"+flag, "--"+f.Name)
+		} else {
+			ratio = StringSimilarRatio(flag, f.Name)
+		}
 		if ratio >= SimilarStringThreshold {
 			similarFlags = append(similarFlags, similarFlag{
 				name:  f.Name,
@@ -47,6 +52,24 @@ func GetMostSimilarFlags(flagSet *pflag.FlagSet, flag string) []string {
 			})
 		}
 	})
+	// cobra doesn't put --version and --help into the flag set
+	// we should check it handly
+	versionSimilarRatio := StringSimilarRatio(flag, "version")
+	if versionSimilarRatio >= SimilarStringThreshold {
+		similarFlags = append(similarFlags, similarFlag{
+			name:  "version",
+			ratio: versionSimilarRatio,
+		})
+	}
+
+	helpSimilarRatio := StringSimilarRatio(flag, "help")
+	if helpSimilarRatio >= SimilarStringThreshold {
+		similarFlags = append(similarFlags, similarFlag{
+			name:  "help",
+			ratio: helpSimilarRatio,
+		})
+	}
+
 	if len(similarFlags) == 0 {
 		return []string{}
 	}

--- a/processor/similar_flags_test.go
+++ b/processor/similar_flags_test.go
@@ -63,6 +63,26 @@ func TestStringSimilarRatio(t *testing.T) {
 			isSimilar: true,
 		},
 		{
+			s1:        "uloc",
+			s2:        "ulc",
+			isSimilar: true,
+		},
+		{
+			s1:        "uloc",
+			s2:        "ulcc",
+			isSimilar: true,
+		},
+		{
+			s1:        "uloc",
+			s2:        "ulocc",
+			isSimilar: true,
+		},
+		{
+			s1:        "--ci",
+			s2:        "--cii",
+			isSimilar: true,
+		},
+		{
 			s1:        "hello",
 			s2:        "hello-world",
 			isSimilar: false,
@@ -97,6 +117,9 @@ func TestGetMostSimilarFlags(t *testing.T) {
 	_ = flags.Bool("no-gitignore", false, "test")
 	_ = flags.Int("no-gitmodule", 0, "test")
 	_ = flags.String("format", "", "test")
+	_ = flags.String("uloc", "", "test")
+	_ = flags.String("gen", "", "test")
+	_ = flags.String("ci", "", "test")
 
 	testCases := []struct {
 		name    string
@@ -121,6 +144,27 @@ func TestGetMostSimilarFlags(t *testing.T) {
 		{
 			name:    "formet",
 			expects: []string{"format"},
+		},
+		{
+			name:    "ulc",
+			expects: []string{"uloc"},
+		},
+		{
+			name:    "gan",
+			expects: []string{"gen"},
+		},
+		{
+			name:    "cii",
+			expects: []string{"ci"},
+		},
+		// these two are not included in the set, but still need to be matched
+		{
+			name:    "vrsion",
+			expects: []string{"version"},
+		},
+		{
+			name:    "hellp",
+			expects: []string{"help"},
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
0.8 is somewhat too precise, making it difficult to match flags like `--uloc`. Therefore, we relaxed the precision to 0.75.

Additionally, for flags with three characters or fewer (`1 < len(flag) <= 3`), 0.75 is still insufficient to match them. Therefore, when encountering such flags, a `--` prefix is now added before them. Increasing the string length enables effective matching of these flags.

Now almost all long flags can provide appropriate spelling suggestions.