### PR TITLE
refactor: add build tests to the CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,25 @@ jobs:
 
     - name: Build
       run: go build -v ./...
+    
+    - name: Windows Build Test
+      run: |
+        GOOS=windows GOARCH=amd64 go build -ldflags="-s -w"
+        GOOS=windows GOARCH=386 go build -ldflags="-s -w"
+        GOOS=windows GOARCH=arm64 go build -ldflags="-s -w"
+    
+    - name: Darwin Build Test
+      run: |
+        GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w"
+        GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w"
+    
+    - name: Linux Build Test
+      run: |
+        GOOS=linux GOARCH=amd64 go build -ldflags="-s -w"
+        GOOS=linux GOARCH=386 go build -ldflags="-s -w"
+        GOOS=linux GOARCH=arm64 go build -ldflags="-s -w"
+        GOOS=linux GOARCH=riscv64 go build -ldflags="-s -w"
+        GOOS=linux GOARCH=loong64 go build -ldflags="-s -w"
 
     - name: Test
       run: go test -v ./...

--- a/test-all.sh
+++ b/test-all.sh
@@ -560,10 +560,13 @@ GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w"
 echo "   windows..."
 GOOS=windows GOARCH=amd64 go build -ldflags="-s -w"
 GOOS=windows GOARCH=386 go build -ldflags="-s -w"
+GOOS=windows GOARCH=arm64 go build -ldflags="-s -w"
 echo "   linux..."
 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w"
 GOOS=linux GOARCH=386 go build -ldflags="-s -w"
 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w"
+GOOS=linux GOARCH=riscv64 go build -ldflags="-s -w"
+GOOS=linux GOARCH=loong64 go build -ldflags="-s -w"
 
 echo -e "${NC}Cleaning up..."
 rm ./scc


### PR DESCRIPTION
Compilation testing, as a specialized form of integration testing, is ideally suited for inclusion in the CI.

Additionally, I've included some extra hardware platform combinations to ensure comprehensive coverage of all common running environments.