### PR TITLE
feat: minor cleanup and optimization

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>30</th>
-		<th>25501</th>
-		<th>1588</th>
-		<th>527</th>
-		<th>23386</th>
-		<th>1748</th>
-		<th>506853</th>
-		<th>7353</th>
+		<th>25531</th>
+		<th>1589</th>
+		<th>524</th>
+		<th>23418</th>
+		<th>1758</th>
+		<th>507695</th>
+		<th>7367</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
 		<td></td>
@@ -43,33 +43,33 @@
 	</tr><tr>
 		<td>processor/formatters_test.go</td>
 		<td></td>
-		<td>1797</td>
-		<td>162</td>
+		<td>1835</td>
+		<td>166</td>
 		<td>4</td>
-		<td>1631</td>
-		<td>169</td>
-		<td>42734</td>
-		<td>486</td>
+		<td>1665</td>
+		<td>181</td>
+		<td>43740</td>
+		<td>501</td>
 	</tr><tr>
 		<td>processor/formatters.go</td>
 		<td></td>
-		<td>1475</td>
-		<td>199</td>
+		<td>1472</td>
+		<td>198</td>
 		<td>31</td>
-		<td>1245</td>
-		<td>158</td>
-		<td>43868</td>
+		<td>1243</td>
+		<td>157</td>
+		<td>43836</td>
 		<td>781</td>
 	</tr><tr>
 		<td>processor/workers.go</td>
 		<td></td>
-		<td>890</td>
-		<td>131</td>
-		<td>95</td>
-		<td>664</td>
-		<td>221</td>
-		<td>26782</td>
-		<td>515</td>
+		<td>872</td>
+		<td>128</td>
+		<td>92</td>
+		<td>652</td>
+		<td>217</td>
+		<td>26349</td>
+		<td>507</td>
 	</tr><tr>
 		<td>main_test.go</td>
 		<td></td>
@@ -83,13 +83,13 @@
 	</tr><tr>
 		<td>processor/processor.go</td>
 		<td></td>
-		<td>630</td>
-		<td>133</td>
+		<td>643</td>
+		<td>134</td>
 		<td>105</td>
-		<td>392</td>
-		<td>79</td>
-		<td>18450</td>
-		<td>420</td>
+		<td>404</td>
+		<td>82</td>
+		<td>18751</td>
+		<td>428</td>
 	</tr><tr>
 		<td>cmd/badges/main.go</td>
 		<td></td>
@@ -281,16 +281,6 @@
 		<td>2209</td>
 		<td>35</td>
 	</tr><tr>
-		<td>processor/cocomo_test.go</td>
-		<td></td>
-		<td>37</td>
-		<td>8</td>
-		<td>4</td>
-		<td>25</td>
-		<td>6</td>
-		<td>686</td>
-		<td>23</td>
-	</tr><tr>
 		<td>processor/bloom.go</td>
 		<td></td>
 		<td>37</td>
@@ -300,6 +290,16 @@
 		<td>2</td>
 		<td>1062</td>
 		<td>29</td>
+	</tr><tr>
+		<td>processor/cocomo_test.go</td>
+		<td></td>
+		<td>37</td>
+		<td>8</td>
+		<td>4</td>
+		<td>25</td>
+		<td>6</td>
+		<td>686</td>
+		<td>23</td>
 	</tr><tr>
 		<td>processor/helpers_test.go</td>
 		<td></td>
@@ -324,15 +324,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>30</th>
-		<th>25501</th>
-		<th>1588</th>
-		<th>527</th>
-		<th>23386</th>
-		<th>1748</th>
-		<th>506853</th>
-		<th>7353</th>
+		<th>25531</th>
+		<th>1589</th>
+		<th>524</th>
+		<th>23418</th>
+		<th>1758</th>
+		<th>507695</th>
+		<th>7367</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $739,603<br>Estimated Schedule Effort (organic) 12.26 months<br>Estimated People Required (organic) 5.36<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $740,666<br>Estimated Schedule Effort (organic) 12.27 months<br>Estimated People Required (organic) 5.36<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -1007,7 +1007,8 @@ func unicodeAwareTrim(tmp string, size int) string {
 	if len(r) > size {
 		for runewidth.StringWidth(tmp) > size {
 			// remove character one at a time till we get the length we want
-			tmp = string([]rune(tmp)[1:])
+			r = r[1:]
+			tmp = string(r)
 		}
 
 		tmp = "~" + strings.TrimSpace(tmp)
@@ -1020,11 +1021,7 @@ func unicodeAwareTrim(tmp string, size int) string {
 // 文中 meaning the size is off... which is annoying, so we implement this ourselves to get it
 // right
 func unicodeAwareRightPad(tmp string, size int) string {
-	for runewidth.StringWidth(tmp) < size {
-		tmp += " "
-	}
-
-	return tmp
+	return runewidth.FillRight(tmp, size)
 }
 
 func fileSummarizeShort(input chan *FileJob) string {

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -1470,6 +1470,44 @@ func TestUnicodeAwareRightPadUnicode(t *testing.T) {
 	}
 }
 
+func BenchmarkUnicodeAwareTrimExactSizeAscii(b *testing.B) {
+	tmp := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.md"
+	for b.Loop() {
+		res := unicodeAwareTrim(tmp, len(tmp))
+		if res != tmp {
+			b.Fatalf("expected %s got %s", tmp, res)
+		}
+	}
+}
+
+func BenchmarkUnicodeAwareTrimUnicode(b *testing.B) {
+	tmp := "中文中文中文中文中文中文中文中文中文中文中文中文中文中文中文中文.md"
+	for b.Loop() {
+		res := unicodeAwareTrim(tmp, shortFormatFileTruncate)
+		if res != "~文中文中文中文中文中文.md" {
+			b.Fatalf("expected ~文中文中文中文中文中文.md got %s", res)
+		}
+	}
+}
+
+func BenchmarkUnicodeAwareRightPad(b *testing.B) {
+	for b.Loop() {
+		tmp := unicodeAwareRightPad("", 10)
+		if runewidth.StringWidth(tmp) != 10 {
+			b.Fatal("expected length of 10")
+		}
+	}
+}
+
+func BenchmarkUnicodeAwareRightPadUnicode(b *testing.B) {
+	for b.Loop() {
+		tmp := unicodeAwareRightPad("中文", 10)
+		if runewidth.StringWidth(tmp) != 10 {
+			b.Fatal("expected length of 10")
+		}
+	}
+}
+
 // When using columise  ~28726 ns/op
 // When using optimised ~14293 ns/op
 func BenchmarkFileSummerize(b *testing.B) {

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -633,10 +633,7 @@ func CountStats(fileJob *FileJob) {
 	isGenerated := false
 
 	if Generated {
-		headLen := 1000
-		if headLen >= len(fileJob.Content) {
-			headLen = len(fileJob.Content) - 1
-		}
+		headLen := min(1000, len(fileJob.Content))
 		head := bytes.ToLower(fileJob.Content[0:headLen])
 		for _, marker := range GeneratedMarkers {
 			if bytes.Contains(head, bytes.ToLower([]byte(marker))) {
@@ -767,12 +764,7 @@ func processFile(job *FileJob) bool {
 
 		// if we didn't remap we then want to see if it's a #! map
 		if !remapped {
-			cutoff := 200
-
-			// To avoid runtime panic check if the content we are cutting is smaller than 200
-			if len(contents) < cutoff {
-				cutoff = len(contents)
-			}
+			cutoff := min(200, len(contents))
 
 			lang, err := DetectSheBang(string(contents[:cutoff]))
 			if err != nil {
@@ -848,12 +840,7 @@ func hardRemapLanguage(job *FileJob) bool {
 	for s := range strings.SplitSeq(RemapAll, ",") {
 		t := strings.Split(s, ":")
 		if len(t) == 2 {
-			cutoff := 1000 // 1000 bytes into the file to look
-
-			// To avoid runtime panic check if the content we are cutting is smaller than 1000
-			if len(job.Content) < cutoff {
-				cutoff = len(job.Content)
-			}
+			cutoff := min(1000, len(job.Content)) // at most 1000 bytes into the file to look
 
 			if strings.Contains(string(job.Content[:cutoff]), t[0]) {
 				job.Language = t[1]
@@ -871,12 +858,7 @@ func unknownRemapLanguage(job *FileJob) bool {
 	for s := range strings.SplitSeq(RemapUnknown, ",") {
 		t := strings.Split(s, ":")
 		if len(t) == 2 {
-			cutoff := 1000 // 1000 bytes into the file to look
-
-			// To avoid runtime panic check if the content we are cutting is smaller than 1000
-			if len(job.Content) < cutoff {
-				cutoff = len(job.Content)
-			}
+			cutoff := min(1000, len(job.Content)) // at most 1000 bytes into the file to look
 
 			if strings.Contains(string(job.Content[:cutoff]), t[0]) {
 				printWarnF("unknown remapping: %s to %s", job.Location, job.Language)


### PR DESCRIPTION
Clean up the code and fix a potential problem:

```go
headLen := 1000
if headLen >= len(fileJob.Content) {
	headLen = len(fileJob.Content) - 1
}
```

This code is missing the last character of the file content. It is fixed by using the builtin function `min`.

We also got some performance improvements:

```console
goos: darwin
goarch: arm64
pkg: github.com/boyter/scc/v3/processor
cpu: Apple M4
                                  │     old      │                 new                 │
                                  │    sec/op    │   sec/op     vs base                │
UnicodeAwareTrimExactSizeAscii-10    41.50n ± 0%   41.27n ± 0%   -0.57% (p=0.002 n=10)
UnicodeAwareTrimUnicode-10           13.09µ ± 1%   10.83µ ± 0%  -17.29% (p=0.000 n=10)
UnicodeAwareRightPad-10             581.20n ± 0%   84.71n ± 0%  -85.43% (p=0.000 n=10)
UnicodeAwareRightPadUnicode-10       556.6n ± 0%   125.6n ± 1%  -77.44% (p=0.000 n=10)
geomean                              647.5n        262.6n       -59.45%

                                  │     old      │                  new                   │
                                  │     B/op     │     B/op      vs base                  │
UnicodeAwareTrimExactSizeAscii-10     144.0 ± 0%     144.0 ± 0%        ~ (p=1.000 n=10) ¹
UnicodeAwareTrimUnicode-10          2.172Ki ± 0%   1.750Ki ± 0%  -19.42% (p=0.000 n=10)
UnicodeAwareRightPad-10               64.00 ± 0%     16.00 ± 0%  -75.00% (p=0.000 n=10)
UnicodeAwareRightPadUnicode-10        80.00 ± 0%     16.00 ± 0%  -80.00% (p=0.000 n=10)
geomean                               201.2          90.15       -55.20%
¹ all samples are equal

                                  │    old     │                 new                  │
                                  │ allocs/op  │ allocs/op   vs base                  │
UnicodeAwareTrimExactSizeAscii-10   1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=10) ¹
UnicodeAwareTrimUnicode-10          26.00 ± 0%   23.00 ± 0%  -11.54% (p=0.000 n=10)
UnicodeAwareRightPad-10             9.000 ± 0%   1.000 ± 0%  -88.89% (p=0.000 n=10)
UnicodeAwareRightPadUnicode-10      6.000 ± 0%   1.000 ± 0%  -83.33% (p=0.000 n=10)
geomean                             6.121        2.190       -64.22%
¹ all samples are equal
```