### PR TITLE
feat: automate file generation and add CI tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,12 +11,30 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version-file: './go.mod'
+    
+    - name: Format Check
+      run: |
+        go fmt ./...
+        if ! git diff --color=always --exit-code -- . ':!vendor'; then
+          echo "::error::Found changed files after 'go fmt ./...'."
+          echo "Please run 'go fmt ./...' and check in all changes."
+          exit 1
+        fi
+    
+    - name: Generate Check
+      run: |
+        go generate
+        if ! git diff --color=always --exit-code -- . ':!vendor'; then
+          echo "::error::Found changed files after 'go generate'."
+          echo "Please run 'go generate' and check in all changes."
+          exit 1
+        fi
 
     - name: Build
       run: go build -v ./...

--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -12,14 +12,14 @@
 	</tr></thead>
 	<tbody><tr>
 		<th>Go</th>
-		<th>32</th>
-		<th>26344</th>
-		<th>1679</th>
-		<th>584</th>
-		<th>24081</th>
-		<th>1856</th>
-		<th>530745</th>
-		<th>7733</th>
+		<th>34</th>
+		<th>26934</th>
+		<th>1752</th>
+		<th>614</th>
+		<th>24568</th>
+		<th>1952</th>
+		<th>547792</th>
+		<th>8014</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
 		<td></td>
@@ -73,13 +73,13 @@
 	</tr><tr>
 		<td>processor/processor.go</td>
 		<td></td>
-		<td>704</td>
+		<td>705</td>
 		<td>151</td>
 		<td>123</td>
-		<td>430</td>
+		<td>431</td>
 		<td>85</td>
-		<td>20885</td>
-		<td>469</td>
+		<td>20926</td>
+		<td>470</td>
 	</tr><tr>
 		<td>main_test.go</td>
 		<td></td>
@@ -103,13 +103,13 @@
 	</tr><tr>
 		<td>main.go</td>
 		<td></td>
-		<td>542</td>
-		<td>17</td>
-		<td>10</td>
-		<td>515</td>
-		<td>24</td>
-		<td>13082</td>
-		<td>339</td>
+		<td>559</td>
+		<td>19</td>
+		<td>12</td>
+		<td>528</td>
+		<td>27</td>
+		<td>13470</td>
+		<td>349</td>
 	</tr><tr>
 		<td>processor/detector_test.go</td>
 		<td></td>
@@ -120,6 +120,16 @@
 		<td>109</td>
 		<td>7784</td>
 		<td>162</td>
+	</tr><tr>
+		<td>mcp.go</td>
+		<td></td>
+		<td>409</td>
+		<td>44</td>
+		<td>25</td>
+		<td>340</td>
+		<td>57</td>
+		<td>12733</td>
+		<td>293</td>
 	</tr><tr>
 		<td>cmd/badges/main_test.go</td>
 		<td></td>
@@ -211,6 +221,16 @@
 		<td>5311</td>
 		<td>117</td>
 	</tr><tr>
+		<td>processor/processor_test.go</td>
+		<td></td>
+		<td>156</td>
+		<td>36</td>
+		<td>1</td>
+		<td>119</td>
+		<td>22</td>
+		<td>2741</td>
+		<td>70</td>
+	</tr><tr>
 		<td>processor/file.go</td>
 		<td></td>
 		<td>153</td>
@@ -220,16 +240,6 @@
 		<td>43</td>
 		<td>3527</td>
 		<td>94</td>
-	</tr><tr>
-		<td>processor/processor_test.go</td>
-		<td></td>
-		<td>151</td>
-		<td>36</td>
-		<td>1</td>
-		<td>114</td>
-		<td>21</td>
-		<td>2573</td>
-		<td>66</td>
 	</tr><tr>
 		<td>processor/structs_test.go</td>
 		<td></td>
@@ -241,6 +251,16 @@
 		<td>3323</td>
 		<td>96</td>
 	</tr><tr>
+		<td>processor/result.go</td>
+		<td></td>
+		<td>135</td>
+		<td>24</td>
+		<td>3</td>
+		<td>108</td>
+		<td>31</td>
+		<td>3150</td>
+		<td>90</td>
+	</tr><tr>
 		<td>processor/trace_test.go</td>
 		<td></td>
 		<td>117</td>
@@ -251,6 +271,16 @@
 		<td>2771</td>
 		<td>80</td>
 	</tr><tr>
+		<td>scripts/include.go</td>
+		<td></td>
+		<td>115</td>
+		<td>22</td>
+		<td>5</td>
+		<td>88</td>
+		<td>23</td>
+		<td>2707</td>
+		<td>73</td>
+	</tr><tr>
 		<td>processor/trace.go</td>
 		<td></td>
 		<td>96</td>
@@ -260,16 +290,6 @@
 		<td>9</td>
 		<td>1957</td>
 		<td>58</td>
-	</tr><tr>
-		<td>scripts/include.go</td>
-		<td></td>
-		<td>92</td>
-		<td>19</td>
-		<td>5</td>
-		<td>68</td>
-		<td>19</td>
-		<td>2140</td>
-		<td>64</td>
 	</tr><tr>
 		<td>processor/similar_flags.go</td>
 		<td></td>
@@ -343,16 +363,16 @@
 	</tr></tbody>
 	<tfoot><tr>
 		<th>Total</th>
-		<th>32</th>
-		<th>26344</th>
-		<th>1679</th>
-		<th>584</th>
-		<th>24081</th>
-		<th>1856</th>
-		<th>530745</th>
-		<th>7733</th>
+		<th>34</th>
+		<th>26934</th>
+		<th>1752</th>
+		<th>614</th>
+		<th>24568</th>
+		<th>1952</th>
+		<th>547792</th>
+		<th>8014</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $762,699<br>Estimated Schedule Effort (organic) 12.41 months<br>Estimated People Required (organic) 5.46<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $778,903<br>Estimated Schedule Effort (organic) 12.51 months<br>Estimated People Required (organic) 5.53<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/mcp.go
+++ b/mcp.go
@@ -87,14 +87,14 @@ Use by_file with sort=complexity to find the most complex files in a project.`),
 }
 
 type mcpAnalyzeResponse struct {
-	Path       string                     `json:"path"`
-	Languages  []mcpLanguageResult        `json:"languages"`
-	Totals     mcpTotals                  `json:"totals"`
-	COCOMO     *mcpCOCOMO                 `json:"cocomo,omitempty"`
-	LOCOMO     *mcpLOCOMO                 `json:"locomo,omitempty"`
-	FileCount  int64                      `json:"totalFiles"`
-	TotalLines int64                      `json:"totalLines"`
-	TotalCode  int64                      `json:"totalCode"`
+	Path       string              `json:"path"`
+	Languages  []mcpLanguageResult `json:"languages"`
+	Totals     mcpTotals           `json:"totals"`
+	COCOMO     *mcpCOCOMO          `json:"cocomo,omitempty"`
+	LOCOMO     *mcpLOCOMO          `json:"locomo,omitempty"`
+	FileCount  int64               `json:"totalFiles"`
+	TotalLines int64               `json:"totalLines"`
+	TotalCode  int64               `json:"totalCode"`
 }
 
 type mcpLanguageResult struct {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -4,6 +4,7 @@ package processor
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -552,7 +553,7 @@ func LanguageDatabase() map[string]Language {
 	return languageDatabase
 }
 
-func printLanguages() {
+func PrintLanguages(dst io.Writer) {
 	names := make([]string, 0, len(languageDatabase))
 	for key := range languageDatabase {
 		names = append(names, key)
@@ -563,7 +564,7 @@ func printLanguages() {
 	})
 
 	for _, name := range names {
-		fmt.Printf("%s (%s)\n", name, strings.Join(append(languageDatabase[name].Extensions, languageDatabase[name].FileNames...), ","))
+		_, _ = fmt.Fprintf(dst, "%s (%s)\n", name, strings.Join(append(languageDatabase[name].Extensions, languageDatabase[name].FileNames...), ","))
 	}
 }
 
@@ -575,7 +576,7 @@ var ulocLanguageCount = map[string]map[string]struct{}{}
 // Process is the main entry point of the command line it sets everything up and starts running
 func Process() {
 	if Languages {
-		printLanguages()
+		PrintLanguages(os.Stdout)
 		return
 	}
 

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -3,6 +3,7 @@
 package processor
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -85,7 +86,11 @@ func TestProcessFlags(t *testing.T) {
 }
 
 func TestPrintLanguages(t *testing.T) {
-	printLanguages()
+	result := &strings.Builder{}
+	PrintLanguages(result)
+	if !strings.Contains(result.String(), "Go Template (tmpl,gohtml,gotxt)\n") {
+		t.Fatal("printLanguages test failed")
+	}
 }
 
 func TestProcess(t *testing.T) {

--- a/scripts/include.go
+++ b/scripts/include.go
@@ -17,7 +17,10 @@ import (
 	jsoniter "github.com/json-iterator/go"
 )
 
-const constantsFile = "./processor/constants.go"
+const (
+	constantsFile     = "./processor/constants.go"
+	languagesListFile = "./LANGUAGES.md"
+)
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
@@ -69,7 +72,7 @@ func generateConstants() error {
 		return fmt.Errorf("failed to format code: %v", err)
 	}
 
-	out, err := os.OpenFile(constantsFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	out, err := os.OpenFile(constantsFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to open constants file: %v", err)
 	}
@@ -84,9 +87,29 @@ func generateConstants() error {
 	return nil
 }
 
+func generateLanguagesList() error {
+	out, err := os.OpenFile(languagesListFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to open languages list file: %v", err)
+	}
+	defer func(file *os.File) {
+		_ = file.Close()
+	}(out)
+
+	_, _ = out.WriteString("```\n")
+	processor.PrintLanguages(out)
+	_, _ = out.WriteString("```\n")
+
+	return nil
+}
+
 func main() {
 	if err := generateConstants(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to generate constants: %v\n", err)
+		os.Exit(1)
+	}
+	if err := generateLanguagesList(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to generate languages list: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/test-all.sh
+++ b/test-all.sh
@@ -30,10 +30,6 @@ fi
 echo "Building application..."
 go build -ldflags="-s -w" || exit
 
-echo '```' > LANGUAGES.md
-./scc --languages >> LANGUAGES.md
-echo '```' >> LANGUAGES.md
-
 
 echo "Building HTML report..."
 


### PR DESCRIPTION
PRs often forget to generate certain necessary files, including my own. So I’ve automated this process and added CI tests so that any omissions will trigger clear error notifications.

The HTTP report (SCC-OUTPUT-REPORT.html) is not included in the scan targets because it changes too frequently and contains a lot of noise; moreover, even if it is not kept up to date, it will not have a significant impact.

Edit: Add an example:

<img width="1198" height="813" alt="image" src="https://github.com/user-attachments/assets/a021e186-d45b-4c6f-a3a1-854911d4cce9" />
