### PR TITLE
Add Move language support (Sui, Aptos, Movement)

### DIFF
--- a/examples/language/move.move
+++ b/examples/language/move.move
@@ -1,0 +1,32 @@
+module example::counter {
+    use std::signer;
+
+    /// A simple counter resource.
+    struct Counter has key {
+        value: u64,
+    }
+
+    /* outer
+       /* nested */ block */
+    public entry fun increment(account: &signer) acquires Counter {
+        let addr = signer::address_of(account);
+        let counter = borrow_global_mut<Counter>(addr);
+        if (counter.value == 0) {
+            counter.value = 1;
+        } else {
+            counter.value = counter.value + 1;
+        };
+    }
+
+    public fun bounded_sum(n: u64): u64 {
+        let i = 0;
+        let total = 0;
+        while (i < n) {
+            if (i % 2 == 0 && i != 0) {
+                total = total + i;
+            };
+            i = i + 1;
+        };
+        total
+    }
+}

--- a/languages.json
+++ b/languages.json
@@ -4918,6 +4918,37 @@
       }
     ]
   },
+  "Move": {
+    "complexitychecks": [
+      "for ",
+      "for(",
+      "if ",
+      "if(",
+      "while ",
+      "while(",
+      "loop ",
+      "loop{",
+      "else ",
+      "else{",
+      "match ",
+      "match(",
+      "|| ",
+      "&& ",
+      "!= ",
+      "== ",
+      "abort "
+    ],
+    "extensions": ["move"],
+    "line_comment": ["//"],
+    "multi_line": [["/*", "*/"]],
+    "nestedmultiline": true,
+    "quotes": [
+      {
+        "end": "\"",
+        "start": "\""
+      }
+    ]
+  },
   "Mustache": {
     "complexitychecks": [
       "for ",

--- a/main_test.go
+++ b/main_test.go
@@ -874,6 +874,7 @@ func TestSpecificLanguages(t *testing.T) {
 		"Mojo",
 		"Monkey C",
 		"Moonbit",
+		"Move",
 		"Nature",
 		"Nushell",
 		"OpenQASM",

--- a/processor/constants.go
+++ b/processor/constants.go
@@ -7896,6 +7896,52 @@ var languageDatabase = map[string]Language{
 		FileNames:       []string{},
 		SheBangs:        []string{},
 	},
+	"Move": {
+		LineComment: []string{
+			"//",
+		},
+		ComplexityChecks: []string{
+			"for ",
+			"for(",
+			"if ",
+			"if(",
+			"while ",
+			"while(",
+			"loop ",
+			"loop{",
+			"else ",
+			"else{",
+			"match ",
+			"match(",
+			"|| ",
+			"&& ",
+			"!= ",
+			"== ",
+			"abort ",
+		},
+		Extensions: []string{
+			"move",
+		},
+		ExtensionFile: false,
+		MultiLine: [][]string{
+			{
+				"/*",
+				"*/",
+			},
+		},
+		Quotes: []Quote{
+			{
+				Start:        "\"",
+				End:          "\"",
+				IgnoreEscape: false,
+				DocString:    false,
+			},
+		},
+		NestedMultiLine: true,
+		Keywords:        []string{},
+		FileNames:       []string{},
+		SheBangs:        []string{},
+	},
 	"Mustache": {
 		LineComment: []string{},
 		ComplexityChecks: []string{


### PR DESCRIPTION
## Summary

Adds support for the [Move](https://move-language.github.io/move/) smart-contract language, used by Sui, Aptos, Starcoin, and Movement. `.move` files are currently silently ignored by scc.

A single language definition covers every dialect — Move 2 (Aptos) is a lexical superset of core Move, and Sui only adds the `entry` modifier; no dialect renames or removes a keyword in a way that would confuse a tokenizer.

Notable choices:
- `nestedmultiline: true` — Move's lexer (`move-compiler/src/parser/lexer.rs`) explicitly tracks nested `/* /* */ */` comments via a stack, like Rust.
- Complexity checks mirror the existing Rust entry plus `match` (Move 2) and `abort ` — Move's panic primitive, used on every error path.
- `b"..."` and `x"..."` byte/hex string prefixes work transparently because string parsing begins at the `"`.

## Test plan

- [x] `go generate ./...` regenerates `processor/constants.go` with the new entry
- [x] `go build` compiles cleanly
- [x] `go test ./...` passes (including `TestSpecificLanguages`, which greps CSV output of `examples/language/`)
- [x] `scc examples/language/move.move` reports correct counts: 32 lines, 3 comments (nested block correctly counted as one region), complexity 8