### PR TITLE
fix: fix tests data race

### DIFF
--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -18,7 +18,7 @@
 		<th>2131</th>
 		<th>34957</th>
 		<th>4478</th>
-		<th>963352</th>
+		<th>963417</th>
 		<th>14602</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
@@ -118,7 +118,7 @@
 		<td>85</td>
 		<td>651</td>
 		<td>199</td>
-		<td>29349</td>
+		<td>29375</td>
 		<td>411</td>
 	</tr><tr>
 		<td>processor/report_render.go</td>
@@ -138,7 +138,7 @@
 		<td>158</td>
 		<td>432</td>
 		<td>152</td>
-		<td>27154</td>
+		<td>27193</td>
 		<td>401</td>
 	</tr><tr>
 		<td>cmd/badges/main.go</td>
@@ -671,16 +671,6 @@
 		<td>2209</td>
 		<td>35</td>
 	</tr><tr>
-		<td>processor/cocomo_test.go</td>
-		<td></td>
-		<td>37</td>
-		<td>8</td>
-		<td>4</td>
-		<td>25</td>
-		<td>6</td>
-		<td>686</td>
-		<td>23</td>
-	</tr><tr>
 		<td>processor/bloom.go</td>
 		<td></td>
 		<td>37</td>
@@ -690,6 +680,16 @@
 		<td>2</td>
 		<td>1056</td>
 		<td>29</td>
+	</tr><tr>
+		<td>processor/cocomo_test.go</td>
+		<td></td>
+		<td>37</td>
+		<td>8</td>
+		<td>4</td>
+		<td>25</td>
+		<td>6</td>
+		<td>686</td>
+		<td>23</td>
 	</tr><tr>
 		<td>processor/helpers_test.go</td>
 		<td></td>
@@ -719,7 +719,7 @@
 		<th>2131</th>
 		<th>34957</th>
 		<th>4478</th>
-		<th>963352</th>
+		<th>963417</th>
 		<th>14602</th>
 	</tr>
 	<tr>

--- a/config_test.go
+++ b/config_test.go
@@ -194,7 +194,7 @@ func TestRegisterFlagsExhaustive(t *testing.T) {
 	t.Parallel()
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	var out, report, multi string
-	registerFlags(fs, &flagBindings{output: &out, report: &report, formatMulti: &multi})
+	registerFlags(fs, &flagBindings{output: &out, report: &report, formatMulti: &multi, inert: true})
 
 	expected := []string{
 		"character", "percent", "uloc", "dryness", "binary", "by-file", "ci",
@@ -227,7 +227,7 @@ func TestRegisterFlagsSliceDefValue(t *testing.T) {
 	t.Parallel()
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	var out, report, multi string
-	registerFlags(fs, &flagBindings{output: &out, report: &report, formatMulti: &multi})
+	registerFlags(fs, &flagBindings{output: &out, report: &report, formatMulti: &multi, inert: true})
 
 	cases := map[string]string{
 		"exclude-dir":       "[.git,.hg,.svn]",

--- a/regression_test.go
+++ b/regression_test.go
@@ -223,7 +223,7 @@ func TestRegressionShorthandsPreserved(t *testing.T) {
 	t.Parallel()
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	var out, report, multi string
-	registerFlags(fs, &flagBindings{output: &out, report: &report, formatMulti: &multi})
+	registerFlags(fs, &flagBindings{output: &out, report: &report, formatMulti: &multi, inert: true})
 	registerConfigControlFlags(fs)
 
 	want := map[string]string{
@@ -279,7 +279,7 @@ func TestRegressionScalarDefaultsPreserved(t *testing.T) {
 	t.Parallel()
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	var out, report, multi string
-	registerFlags(fs, &flagBindings{output: &out, report: &report, formatMulti: &multi})
+	registerFlags(fs, &flagBindings{output: &out, report: &report, formatMulti: &multi, inert: true})
 
 	wantDef := map[string]string{
 		"format":              "tabular",
@@ -319,7 +319,7 @@ func TestRegressionScalarDefaultsPreserved(t *testing.T) {
 func processorDefaultReportName() string {
 	fs := pflag.NewFlagSet("probe", pflag.ContinueOnError)
 	var out, report, multi string
-	registerFlags(fs, &flagBindings{output: &out, report: &report, formatMulti: &multi})
+	registerFlags(fs, &flagBindings{output: &out, report: &report, formatMulti: &multi, inert: true})
 	return fs.Lookup("report").NoOptDefVal
 }
 


### PR DESCRIPTION
Some parallel tests cause data races because they accidentally modify global variables. You can reproduce the issue using the following command:

```console
go test -race -count=50 -run 'TestPreScanConfig|TestRegisterFlagsSliceDefValue|TestRegisterFlagsExhaustive|TestRegressionScalarDefaultsPreserved|TestRegressionShorthandsPreserved' .
```

These tests themselves do not rely on global state, so fix them so that they do not affect global variables.