### PR TITLE
Cognitive Complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ features listed below may be missing from your installation.
 ```text
 $ scc -h
 Sloc, Cloc and Code. Count lines of code in a directory with complexity estimation.
-Version 3.8.0 (beta)
+Version 4.0.0 (beta)
 Ben Boyter <ben@boyter.org> + Contributors
 
 Usage:
@@ -295,6 +295,10 @@ Examples:
     scc --report
     scc --report=out.html --report-title "myrepo" --report-skip cocomo
 
+  Use a project config file (./.sccconfig) or a global one (precedence: global < project < CLI):
+    export SCC_CONFIG_PATH=~/.sccconfig
+    scc --config team.sccconfig
+
 Flags:
       --avg-wage int                        average wage value used for basic COCOMO calculation (default 56286)
       --binary                              disable binary file detection
@@ -304,6 +308,8 @@ Flags:
   -m, --character                           calculate max and mean characters per line
       --ci                                  enable CI output settings where stdout is ASCII
       --cocomo-project-type string          change COCOMO model type [organic, semi-detached, embedded, "custom,1,1,1,1"] (default "organic")
+      --cognitive                           calculate cognitive (nesting-weighted) complexity
+      --config string                       load this file as the global config source; overrides SCC_CONFIG_PATH, honored even with --no-config
       --cost-comparison                     show both COCOMO and LOCOMO estimates side by side
       --count-as string                     count extension as language [e.g. jsp:htm,chead:"C Header" maps extension jsp to html and chead to C Header]
       --count-as-pattern stringArray        count files matching a path pattern as a new named category backed by a base language [repeatable; pattern is glob by default, prefix with re: for regex; e.g. *_spec.rb:"Ruby Spec":Ruby or re:\.test\.js$:"JavaScript Tests":JavaScript]
@@ -321,6 +327,7 @@ Flags:
       --file-list-queue-size int            the size of the queue of files found and ready to be read into memory (default 8)
       --file-process-job-workers int        number of goroutine workers that process files collecting stats (default 8)
       --file-summary-job-queue-size int     the size of the queue used to hold processed file statistics before formatting (default 8)
+      --find-root-config                    discover the project .sccconfig by walking up to the repository root instead of using ./.sccconfig
   -f, --format string                       set output format [tabular, wide, json, json2, csv, csv-stream, cloc-yaml, html, html-table, sql, sql-insert, openmetrics] (default "tabular")
       --format-multi string                 have multiple format output overriding --format [e.g. tabular:stdout,csv:file.csv,json:file.json]
       --gen                                 identify generated files
@@ -347,6 +354,7 @@ Flags:
       --min-gen-line-length int             number of bytes per average line for file to be considered minified or generated (default 255)
       --no-cocomo                           remove COCOMO calculation output
   -c, --no-complexity                       skip calculation of code complexity
+      --no-config                           disable auto-discovery of the SCC_CONFIG_PATH global and the project ./.sccconfig config
   -d, --no-duplicates                       remove duplicate files from stats and output
       --no-fold-authors                     disable the name+email-domain identity folding fallback for git author reports (mailmap still applied)
       --no-gen                              ignore generated files in output (implies --gen)

--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -13,13 +13,13 @@
 	<tbody><tr>
 		<th>Go</th>
 		<th>74</th>
-		<th>41690</th>
-		<th>3209</th>
-		<th>2346</th>
-		<th>36135</th>
-		<th>4747</th>
-		<th>1014788</th>
-		<th>15420</th>
+		<th>41768</th>
+		<th>3217</th>
+		<th>2368</th>
+		<th>36183</th>
+		<th>4758</th>
+		<th>1017905</th>
+		<th>15466</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
 		<td></td>
@@ -68,7 +68,7 @@
 		<td>127</td>
 		<td>764</td>
 		<td>266</td>
-		<td>31848</td>
+		<td>31835</td>
 		<td>606</td>
 	</tr><tr>
 		<td>main_test.go</td>
@@ -221,16 +221,6 @@
 		<td>15568</td>
 		<td>242</td>
 	</tr><tr>
-		<td>processor/history_languages_test.go</td>
-		<td></td>
-		<td>422</td>
-		<td>44</td>
-		<td>49</td>
-		<td>329</td>
-		<td>73</td>
-		<td>13401</td>
-		<td>230</td>
-	</tr><tr>
 		<td>processor/history_hotspots.go</td>
 		<td></td>
 		<td>422</td>
@@ -240,6 +230,16 @@
 		<td>57</td>
 		<td>12218</td>
 		<td>305</td>
+	</tr><tr>
+		<td>processor/history_languages_test.go</td>
+		<td></td>
+		<td>422</td>
+		<td>44</td>
+		<td>49</td>
+		<td>329</td>
+		<td>73</td>
+		<td>13401</td>
+		<td>230</td>
 	</tr><tr>
 		<td>processor/history_author_timeline.go</td>
 		<td></td>
@@ -301,6 +301,16 @@
 		<td>8923</td>
 		<td>212</td>
 	</tr><tr>
+		<td>processor/structs.go</td>
+		<td></td>
+		<td>327</td>
+		<td>31</td>
+		<td>55</td>
+		<td>241</td>
+		<td>27</td>
+		<td>11821</td>
+		<td>248</td>
+	</tr><tr>
 		<td>processor/workers_cognitive_test.go</td>
 		<td></td>
 		<td>325</td>
@@ -341,6 +351,16 @@
 		<td>7048</td>
 		<td>155</td>
 	</tr><tr>
+		<td>processor/formatters_cognitive_test.go</td>
+		<td></td>
+		<td>287</td>
+		<td>38</td>
+		<td>35</td>
+		<td>214</td>
+		<td>48</td>
+		<td>9128</td>
+		<td>155</td>
+	</tr><tr>
 		<td>processor/history_blame_test.go</td>
 		<td></td>
 		<td>286</td>
@@ -351,16 +371,6 @@
 		<td>9317</td>
 		<td>185</td>
 	</tr><tr>
-		<td>processor/structs.go</td>
-		<td></td>
-		<td>285</td>
-		<td>27</td>
-		<td>39</td>
-		<td>219</td>
-		<td>25</td>
-		<td>10015</td>
-		<td>217</td>
-	</tr><tr>
 		<td>processor/locomo_test.go</td>
 		<td></td>
 		<td>272</td>
@@ -370,16 +380,6 @@
 		<td>68</td>
 		<td>7503</td>
 		<td>131</td>
-	</tr><tr>
-		<td>processor/formatters_cognitive_test.go</td>
-		<td></td>
-		<td>251</td>
-		<td>34</td>
-		<td>29</td>
-		<td>188</td>
-		<td>39</td>
-		<td>7804</td>
-		<td>137</td>
 	</tr><tr>
 		<td>processor/workers_regression_test.go</td>
 		<td></td>
@@ -721,16 +721,6 @@
 		<td>2209</td>
 		<td>35</td>
 	</tr><tr>
-		<td>processor/bloom.go</td>
-		<td></td>
-		<td>37</td>
-		<td>7</td>
-		<td>12</td>
-		<td>18</td>
-		<td>2</td>
-		<td>1056</td>
-		<td>29</td>
-	</tr><tr>
 		<td>processor/cocomo_test.go</td>
 		<td></td>
 		<td>37</td>
@@ -740,6 +730,16 @@
 		<td>6</td>
 		<td>686</td>
 		<td>23</td>
+	</tr><tr>
+		<td>processor/bloom.go</td>
+		<td></td>
+		<td>37</td>
+		<td>7</td>
+		<td>12</td>
+		<td>18</td>
+		<td>2</td>
+		<td>1056</td>
+		<td>29</td>
 	</tr><tr>
 		<td>processor/helpers_test.go</td>
 		<td></td>
@@ -764,15 +764,15 @@
 	<tfoot><tr>
 		<th>Total</th>
 		<th>74</th>
-		<th>41690</th>
-		<th>3209</th>
-		<th>2346</th>
-		<th>36135</th>
-		<th>4747</th>
-		<th>1014788</th>
-		<th>15420</th>
+		<th>41768</th>
+		<th>3217</th>
+		<th>2368</th>
+		<th>36183</th>
+		<th>4758</th>
+		<th>1017905</th>
+		<th>15466</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $1,167,937<br>Estimated Schedule Effort (organic) 14.59 months<br>Estimated People Required (organic) 7.11<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $1,169,567<br>Estimated Schedule Effort (organic) 14.60 months<br>Estimated People Required (organic) 7.12<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/SCC-OUTPUT-REPORT.html
+++ b/SCC-OUTPUT-REPORT.html
@@ -12,14 +12,14 @@
 	</tr></thead>
 	<tbody><tr>
 		<th>Go</th>
-		<th>69</th>
-		<th>40302</th>
-		<th>3053</th>
-		<th>2160</th>
-		<th>35089</th>
-		<th>4498</th>
-		<th>969074</th>
-		<th>14702</th>
+		<th>74</th>
+		<th>41690</th>
+		<th>3209</th>
+		<th>2346</th>
+		<th>36135</th>
+		<th>4747</th>
+		<th>1014788</th>
+		<th>15420</th>
 	</tr><tr>
 		<td>processor/constants.go</td>
 		<td></td>
@@ -53,13 +53,23 @@
 	</tr><tr>
 		<td>processor/processor.go</td>
 		<td></td>
-		<td>1066</td>
-		<td>200</td>
-		<td>200</td>
-		<td>666</td>
-		<td>157</td>
-		<td>32980</td>
-		<td>701</td>
+		<td>1078</td>
+		<td>202</td>
+		<td>205</td>
+		<td>671</td>
+		<td>159</td>
+		<td>33512</td>
+		<td>709</td>
+	</tr><tr>
+		<td>processor/workers.go</td>
+		<td></td>
+		<td>1041</td>
+		<td>150</td>
+		<td>127</td>
+		<td>764</td>
+		<td>266</td>
+		<td>31848</td>
+		<td>606</td>
 	</tr><tr>
 		<td>main_test.go</td>
 		<td></td>
@@ -81,25 +91,25 @@
 		<td>33373</td>
 		<td>578</td>
 	</tr><tr>
-		<td>processor/workers.go</td>
-		<td></td>
-		<td>966</td>
-		<td>146</td>
-		<td>102</td>
-		<td>718</td>
-		<td>244</td>
-		<td>29128</td>
-		<td>552</td>
-	</tr><tr>
 		<td>processor/history.go</td>
 		<td></td>
-		<td>817</td>
-		<td>82</td>
-		<td>135</td>
-		<td>600</td>
-		<td>173</td>
-		<td>24409</td>
-		<td>504</td>
+		<td>837</td>
+		<td>83</td>
+		<td>139</td>
+		<td>615</td>
+		<td>175</td>
+		<td>25272</td>
+		<td>517</td>
+	</tr><tr>
+		<td>config_test.go</td>
+		<td></td>
+		<td>831</td>
+		<td>56</td>
+		<td>91</td>
+		<td>684</td>
+		<td>206</td>
+		<td>31320</td>
+		<td>434</td>
 	</tr><tr>
 		<td>processor/report.go</td>
 		<td></td>
@@ -110,16 +120,6 @@
 		<td>112</td>
 		<td>22613</td>
 		<td>581</td>
-	</tr><tr>
-		<td>config_test.go</td>
-		<td></td>
-		<td>786</td>
-		<td>50</td>
-		<td>85</td>
-		<td>651</td>
-		<td>199</td>
-		<td>29375</td>
-		<td>411</td>
 	</tr><tr>
 		<td>processor/report_render.go</td>
 		<td></td>
@@ -138,7 +138,7 @@
 		<td>158</td>
 		<td>432</td>
 		<td>152</td>
-		<td>27193</td>
+		<td>27391</td>
 		<td>401</td>
 	</tr><tr>
 		<td>cmd/badges/main.go</td>
@@ -173,13 +173,13 @@
 	</tr><tr>
 		<td>config.go</td>
 		<td></td>
-		<td>585</td>
+		<td>586</td>
 		<td>51</td>
 		<td>111</td>
-		<td>423</td>
+		<td>424</td>
 		<td>77</td>
-		<td>27979</td>
-		<td>421</td>
+		<td>28134</td>
+		<td>422</td>
 	</tr><tr>
 		<td>processor/history_author_timeline_test.go</td>
 		<td></td>
@@ -203,23 +203,23 @@
 	</tr><tr>
 		<td>mcp.go</td>
 		<td></td>
-		<td>493</td>
-		<td>56</td>
+		<td>509</td>
+		<td>57</td>
 		<td>34</td>
-		<td>403</td>
-		<td>71</td>
-		<td>15957</td>
-		<td>328</td>
+		<td>418</td>
+		<td>74</td>
+		<td>16655</td>
+		<td>340</td>
 	</tr><tr>
 		<td>processor/formatters_tabular.go</td>
 		<td></td>
-		<td>461</td>
-		<td>75</td>
-		<td>9</td>
-		<td>377</td>
-		<td>78</td>
-		<td>13886</td>
-		<td>227</td>
+		<td>489</td>
+		<td>76</td>
+		<td>11</td>
+		<td>402</td>
+		<td>86</td>
+		<td>15568</td>
+		<td>242</td>
 	</tr><tr>
 		<td>processor/history_languages_test.go</td>
 		<td></td>
@@ -231,6 +231,16 @@
 		<td>13401</td>
 		<td>230</td>
 	</tr><tr>
+		<td>processor/history_hotspots.go</td>
+		<td></td>
+		<td>422</td>
+		<td>40</td>
+		<td>47</td>
+		<td>335</td>
+		<td>57</td>
+		<td>12218</td>
+		<td>305</td>
+	</tr><tr>
 		<td>processor/history_author_timeline.go</td>
 		<td></td>
 		<td>414</td>
@@ -241,15 +251,15 @@
 		<td>11760</td>
 		<td>288</td>
 	</tr><tr>
-		<td>processor/history_hotspots.go</td>
+		<td>processor/history_languages.go</td>
 		<td></td>
-		<td>412</td>
+		<td>373</td>
 		<td>40</td>
-		<td>43</td>
-		<td>329</td>
-		<td>56</td>
-		<td>11794</td>
-		<td>296</td>
+		<td>30</td>
+		<td>303</td>
+		<td>52</td>
+		<td>10482</td>
+		<td>269</td>
 	</tr><tr>
 		<td>processor/file_test.go</td>
 		<td></td>
@@ -261,15 +271,15 @@
 		<td>8978</td>
 		<td>178</td>
 	</tr><tr>
-		<td>processor/history_languages.go</td>
+		<td>processor/formatters.go</td>
 		<td></td>
-		<td>373</td>
-		<td>40</td>
-		<td>30</td>
-		<td>303</td>
-		<td>52</td>
-		<td>10482</td>
-		<td>269</td>
+		<td>341</td>
+		<td>34</td>
+		<td>18</td>
+		<td>289</td>
+		<td>49</td>
+		<td>10079</td>
+		<td>199</td>
 	</tr><tr>
 		<td>processor/detector.go</td>
 		<td></td>
@@ -291,6 +301,16 @@
 		<td>8923</td>
 		<td>212</td>
 	</tr><tr>
+		<td>processor/workers_cognitive_test.go</td>
+		<td></td>
+		<td>325</td>
+		<td>46</td>
+		<td>22</td>
+		<td>257</td>
+		<td>56</td>
+		<td>9327</td>
+		<td>172</td>
+	</tr><tr>
 		<td>processor/history_blame.go</td>
 		<td></td>
 		<td>311</td>
@@ -300,16 +320,6 @@
 		<td>59</td>
 		<td>8670</td>
 		<td>225</td>
-	</tr><tr>
-		<td>processor/formatters.go</td>
-		<td></td>
-		<td>304</td>
-		<td>31</td>
-		<td>11</td>
-		<td>262</td>
-		<td>44</td>
-		<td>8599</td>
-		<td>178</td>
 	</tr><tr>
 		<td>cmd/badges/main_test.go</td>
 		<td></td>
@@ -343,13 +353,13 @@
 	</tr><tr>
 		<td>processor/structs.go</td>
 		<td></td>
-		<td>281</td>
+		<td>285</td>
 		<td>27</td>
 		<td>39</td>
-		<td>215</td>
+		<td>219</td>
 		<td>25</td>
-		<td>9537</td>
-		<td>213</td>
+		<td>10015</td>
+		<td>217</td>
 	</tr><tr>
 		<td>processor/locomo_test.go</td>
 		<td></td>
@@ -360,6 +370,16 @@
 		<td>68</td>
 		<td>7503</td>
 		<td>131</td>
+	</tr><tr>
+		<td>processor/formatters_cognitive_test.go</td>
+		<td></td>
+		<td>251</td>
+		<td>34</td>
+		<td>29</td>
+		<td>188</td>
+		<td>39</td>
+		<td>7804</td>
+		<td>137</td>
 	</tr><tr>
 		<td>processor/workers_regression_test.go</td>
 		<td></td>
@@ -381,6 +401,16 @@
 		<td>4027</td>
 		<td>125</td>
 	</tr><tr>
+		<td>processor/formatters_csv.go</td>
+		<td></td>
+		<td>240</td>
+		<td>23</td>
+		<td>10</td>
+		<td>207</td>
+		<td>15</td>
+		<td>5911</td>
+		<td>145</td>
+	</tr><tr>
 		<td>main.go</td>
 		<td></td>
 		<td>230</td>
@@ -388,7 +418,7 @@
 		<td>43</td>
 		<td>161</td>
 		<td>40</td>
-		<td>8263</td>
+		<td>8293</td>
 		<td>175</td>
 	</tr><tr>
 		<td>processor/history_validation_test.go</td>
@@ -431,6 +461,16 @@
 		<td>6017</td>
 		<td>138</td>
 	</tr><tr>
+		<td>processor/cognitive_nesting_test.go</td>
+		<td></td>
+		<td>194</td>
+		<td>19</td>
+		<td>47</td>
+		<td>128</td>
+		<td>26</td>
+		<td>6064</td>
+		<td>135</td>
+	</tr><tr>
 		<td>processor/formatters_cost.go</td>
 		<td></td>
 		<td>190</td>
@@ -440,16 +480,6 @@
 		<td>17</td>
 		<td>7566</td>
 		<td>138</td>
-	</tr><tr>
-		<td>processor/formatters_csv.go</td>
-		<td></td>
-		<td>188</td>
-		<td>23</td>
-		<td>7</td>
-		<td>158</td>
-		<td>5</td>
-		<td>4600</td>
-		<td>121</td>
 	</tr><tr>
 		<td>processor/file.go</td>
 		<td></td>
@@ -470,6 +500,16 @@
 		<td>5</td>
 		<td>3105</td>
 		<td>78</td>
+	</tr><tr>
+		<td>mcp_test.go</td>
+		<td></td>
+		<td>170</td>
+		<td>24</td>
+		<td>16</td>
+		<td>130</td>
+		<td>37</td>
+		<td>4975</td>
+		<td>109</td>
 	</tr><tr>
 		<td>processor/locomo.go</td>
 		<td></td>
@@ -501,6 +541,16 @@
 		<td>3323</td>
 		<td>96</td>
 	</tr><tr>
+		<td>processor/formatters_sql.go</td>
+		<td></td>
+		<td>141</td>
+		<td>14</td>
+		<td>5</td>
+		<td>122</td>
+		<td>11</td>
+		<td>3810</td>
+		<td>111</td>
+	</tr><tr>
 		<td>processor/result.go</td>
 		<td></td>
 		<td>138</td>
@@ -511,15 +561,15 @@
 		<td>3291</td>
 		<td>93</td>
 	</tr><tr>
-		<td>processor/formatters_sql.go</td>
+		<td>processor/history_cognitive_test.go</td>
 		<td></td>
-		<td>127</td>
-		<td>14</td>
-		<td>5</td>
-		<td>108</td>
-		<td>8</td>
-		<td>3307</td>
-		<td>104</td>
+		<td>134</td>
+		<td>15</td>
+		<td>16</td>
+		<td>103</td>
+		<td>28</td>
+		<td>4525</td>
+		<td>98</td>
 	</tr><tr>
 		<td>processor/history_cache_test.go</td>
 		<td></td>
@@ -671,16 +721,6 @@
 		<td>2209</td>
 		<td>35</td>
 	</tr><tr>
-		<td>processor/cocomo_test.go</td>
-		<td></td>
-		<td>37</td>
-		<td>8</td>
-		<td>4</td>
-		<td>25</td>
-		<td>6</td>
-		<td>686</td>
-		<td>23</td>
-	</tr><tr>
 		<td>processor/bloom.go</td>
 		<td></td>
 		<td>37</td>
@@ -690,6 +730,16 @@
 		<td>2</td>
 		<td>1056</td>
 		<td>29</td>
+	</tr><tr>
+		<td>processor/cocomo_test.go</td>
+		<td></td>
+		<td>37</td>
+		<td>8</td>
+		<td>4</td>
+		<td>25</td>
+		<td>6</td>
+		<td>686</td>
+		<td>23</td>
 	</tr><tr>
 		<td>processor/helpers_test.go</td>
 		<td></td>
@@ -713,16 +763,16 @@
 	</tr></tbody>
 	<tfoot><tr>
 		<th>Total</th>
-		<th>69</th>
-		<th>40302</th>
-		<th>3053</th>
-		<th>2160</th>
-		<th>35089</th>
-		<th>4498</th>
-		<th>969074</th>
-		<th>14702</th>
+		<th>74</th>
+		<th>41690</th>
+		<th>3209</th>
+		<th>2346</th>
+		<th>36135</th>
+		<th>4747</th>
+		<th>1014788</th>
+		<th>15420</th>
 	</tr>
 	<tr>
-		<th colspan="9">Estimated Cost to Develop (organic) $1,132,465<br>Estimated Schedule Effort (organic) 14.42 months<br>Estimated People Required (organic) 6.98<br></th>
+		<th colspan="9">Estimated Cost to Develop (organic) $1,167,937<br>Estimated Schedule Effort (organic) 14.59 months<br>Estimated People Required (organic) 7.11<br></th>
 	</tr></tfoot>
 	</table></body></html>

--- a/config.go
+++ b/config.go
@@ -335,6 +335,7 @@ func registerFlags(flags *pflag.FlagSet, b *flagBindings) {
 	flags.BoolVarP(boolVar(&processor.Percent), "percent", "p", false, "include percentage values in output")
 	flags.BoolVarP(boolVar(&processor.UlocMode), "uloc", "u", false, "calculate the number of unique lines of code (ULOC) for the project")
 	flags.BoolVarP(boolVar(&processor.Dryness), "dryness", "a", false, "calculate the DRYness of the project (implies --uloc)")
+	flags.BoolVar(boolVar(&processor.Cognitive), "cognitive", false, "calculate cognitive (nesting-weighted) complexity")
 	flags.BoolVar(boolVar(&processor.DisableCheckBinary), "binary", false, "disable binary file detection")
 	flags.BoolVar(boolVar(&processor.Files), "by-file", false, "display output for every file")
 	flags.BoolVar(boolVar(&processor.Ci), "ci", false, "enable CI output settings where stdout is ASCII")

--- a/config_test.go
+++ b/config_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/boyter/scc/v3/processor"
 	"github.com/spf13/pflag"
 )
 
@@ -197,7 +198,7 @@ func TestRegisterFlagsExhaustive(t *testing.T) {
 	registerFlags(fs, &flagBindings{output: &out, report: &report, formatMulti: &multi, inert: true})
 
 	expected := []string{
-		"character", "percent", "uloc", "dryness", "binary", "by-file", "ci",
+		"character", "percent", "uloc", "dryness", "cognitive", "binary", "by-file", "ci",
 		"no-ignore", "no-scc-ignore", "no-gitignore", "no-gitmodule", "count-ignore",
 		"ignore-file",
 		"debug", "exclude-dir", "file-gc-count", "file-list-queue-size",
@@ -242,6 +243,50 @@ func TestRegisterFlagsSliceDefValue(t *testing.T) {
 		if f.DefValue != want {
 			t.Errorf("--%s DefValue = %q, want %q", name, f.DefValue, want)
 		}
+	}
+}
+
+// TestCognitiveFlagParses asserts that parsing --cognitive on the real flag set
+// toggles the processor.Cognitive global.
+func TestCognitiveFlagParses(t *testing.T) {
+	prev := processor.Cognitive
+	defer func() { processor.Cognitive = prev }()
+	processor.Cognitive = false
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	var out, report, multi string
+	registerFlags(fs, &flagBindings{output: &out, report: &report, formatMulti: &multi})
+
+	if err := fs.Parse([]string{"--cognitive"}); err != nil {
+		t.Fatalf("parse --cognitive: %v", err)
+	}
+	if !processor.Cognitive {
+		t.Error("parsing --cognitive did not set processor.Cognitive")
+	}
+}
+
+// TestCognitiveFlagConfigRoundTrip writes a .sccconfig containing --cognitive,
+// parses it back through the same config-arg reader and flag set that scc uses
+// at startup, and asserts the flag survives the round-trip. Mirrors how a bool
+// flag reaches the real global from a project config file.
+func TestCognitiveFlagConfigRoundTrip(t *testing.T) {
+	prev := processor.Cognitive
+	defer func() { processor.Cognitive = prev }()
+	processor.Cognitive = false
+
+	args := parseConfigArgs("--cognitive\n", false)
+	if !slices.Equal(args, []string{"--cognitive"}) {
+		t.Fatalf("config parse produced %q, want [--cognitive]", args)
+	}
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	var out, report, multi string
+	registerFlags(fs, &flagBindings{output: &out, report: &report, formatMulti: &multi})
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("parse config args: %v", err)
+	}
+	if !processor.Cognitive {
+		t.Error("--cognitive from config did not set processor.Cognitive")
 	}
 }
 

--- a/mcp.go
+++ b/mcp.go
@@ -40,6 +40,7 @@ Returns per-language summary with:
 - comment: lines of comments
 - blank: blank lines
 - complexity: estimated cyclomatic complexity
+- cognitive: nesting-weighted cognitive complexity (only when cognitive=true; 0 otherwise)
 - bytes: total size in bytes
 
 Also returns COCOMO cost/schedule estimates and optionally LOCOMO (LLM cost) estimates.
@@ -68,6 +69,9 @@ Use by_file with sort=complexity to find the most complex files in a project.`),
 		),
 		mcp.WithBoolean("no_min_gen",
 			mcp.Description("Exclude minified or generated files."),
+		),
+		mcp.WithBoolean("cognitive",
+			mcp.Description("Compute nesting-weighted cognitive complexity in addition to cyclomatic complexity. Adds a 'cognitive' field to per-language, per-file and totals results. Off by default; when off the field is 0."),
 		),
 		mcp.WithBoolean("locomo",
 			mcp.Description("Include LOCOMO (LLM Output COst MOdel) cost estimation in results."),
@@ -132,6 +136,7 @@ type mcpLanguageResult struct {
 	Comment    int64           `json:"comment"`
 	Blank      int64           `json:"blank"`
 	Complexity int64           `json:"complexity"`
+	Cognitive  int64           `json:"cognitive"`
 	Bytes      int64           `json:"bytes"`
 	FileList   []mcpFileResult `json:"fileList,omitempty"`
 }
@@ -145,6 +150,7 @@ type mcpFileResult struct {
 	Comment    int64  `json:"comment"`
 	Blank      int64  `json:"blank"`
 	Complexity int64  `json:"complexity"`
+	Cognitive  int64  `json:"cognitive"`
 	Bytes      int64  `json:"bytes"`
 }
 
@@ -155,6 +161,7 @@ type mcpTotals struct {
 	Comment    int64 `json:"comment"`
 	Blank      int64 `json:"blank"`
 	Complexity int64 `json:"complexity"`
+	Cognitive  int64 `json:"cognitive"`
 	Bytes      int64 `json:"bytes"`
 }
 
@@ -259,6 +266,12 @@ func mcpAnalyzeHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.C
 		processor.IgnoreMinifiedGenerate = false
 	}
 
+	if cognitive, ok := args["cognitive"].(bool); ok && cognitive {
+		processor.Cognitive = true
+	} else {
+		processor.Cognitive = false
+	}
+
 	if locomo, ok := args["locomo"].(bool); ok && locomo {
 		processor.Locomo = true
 	} else {
@@ -292,6 +305,7 @@ func mcpAnalyzeHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.C
 			Comment:    l.Comment,
 			Blank:      l.Blank,
 			Complexity: l.Complexity,
+			Cognitive:  l.Cognitive,
 			Bytes:      l.Bytes,
 		}
 
@@ -315,6 +329,7 @@ func mcpAnalyzeHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.C
 					Comment:    f.Comment,
 					Blank:      f.Blank,
 					Complexity: f.Complexity,
+					Cognitive:  f.Cognitive,
 					Bytes:      f.Bytes,
 				})
 			}
@@ -328,6 +343,7 @@ func mcpAnalyzeHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.C
 		totals.Comment += l.Comment
 		totals.Blank += l.Blank
 		totals.Complexity += l.Complexity
+		totals.Cognitive += l.Cognitive
 		totals.Bytes += l.Bytes
 	}
 

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// nestedCognitiveSource is a small Go file whose branch keywords are nested,
+// so cognitive complexity (nesting-weighted) exceeds plain cyclomatic
+// complexity when the metric is enabled.
+const nestedCognitiveSource = `package sample
+
+func deeplyNested(items []int) int {
+	total := 0
+	for _, v := range items {
+		if v > 0 {
+			for i := 0; i < v; i++ {
+				if i%2 == 0 {
+					total += i
+				}
+			}
+		}
+	}
+	return total
+}
+`
+
+// callAnalyze runs the MCP analyze handler against dir with the supplied args
+// and returns the decoded response.
+func callAnalyze(t *testing.T, dir string, args map[string]any) mcpAnalyzeResponse {
+	t.Helper()
+
+	if args == nil {
+		args = map[string]any{}
+	}
+	args["path"] = dir
+
+	req := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "analyze",
+			Arguments: args,
+		},
+	}
+
+	result, err := mcpAnalyzeHandler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("mcpAnalyzeHandler returned error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("mcpAnalyzeHandler returned tool error: %+v", result.Content)
+	}
+	if len(result.Content) == 0 {
+		t.Fatalf("mcpAnalyzeHandler returned no content")
+	}
+
+	text, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	}
+
+	var resp mcpAnalyzeResponse
+	if err := json.Unmarshal([]byte(text.Text), &resp); err != nil {
+		t.Fatalf("failed to decode analyze response: %v\n%s", err, text.Text)
+	}
+	return resp
+}
+
+func writeNestedFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "sample.go"), []byte(nestedCognitiveSource), 0644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+	return dir
+}
+
+// TestMcpAnalyzeCognitiveEnabled verifies that requesting cognitive=true
+// yields a non-zero cognitive metric at the per-language, per-file and totals
+// levels, and that the totals equal the sum of the per-language values.
+func TestMcpAnalyzeCognitiveEnabled(t *testing.T) {
+	dir := writeNestedFixture(t)
+
+	resp := callAnalyze(t, dir, map[string]any{
+		"cognitive": true,
+		"by_file":   true,
+	})
+
+	if len(resp.Languages) == 0 {
+		t.Fatalf("expected at least one language in response")
+	}
+
+	var sumLang int64
+	for _, l := range resp.Languages {
+		sumLang += l.Cognitive
+	}
+
+	if resp.Totals.Cognitive <= 0 {
+		t.Fatalf("expected non-zero cognitive total, got %d", resp.Totals.Cognitive)
+	}
+	if sumLang != resp.Totals.Cognitive {
+		t.Fatalf("totals cognitive (%d) != sum of per-language cognitive (%d)", resp.Totals.Cognitive, sumLang)
+	}
+
+	// Cognitive should exceed plain cyclomatic complexity for this nested input.
+	if resp.Totals.Cognitive <= resp.Totals.Complexity {
+		t.Fatalf("expected cognitive (%d) > complexity (%d) for nested source", resp.Totals.Cognitive, resp.Totals.Complexity)
+	}
+
+	// Per-file cognitive must be populated too.
+	var fileCognitive int64
+	for _, l := range resp.Languages {
+		for _, f := range l.FileList {
+			fileCognitive += f.Cognitive
+		}
+	}
+	if fileCognitive != resp.Totals.Cognitive {
+		t.Fatalf("sum of per-file cognitive (%d) != totals cognitive (%d)", fileCognitive, resp.Totals.Cognitive)
+	}
+}
+
+// TestMcpAnalyzeCognitiveDisabled verifies that without the opt-in parameter
+// the cognitive field is zero everywhere, leaving default output unchanged.
+func TestMcpAnalyzeCognitiveDisabled(t *testing.T) {
+	dir := writeNestedFixture(t)
+
+	resp := callAnalyze(t, dir, map[string]any{
+		"by_file": true,
+	})
+
+	if resp.Totals.Cognitive != 0 {
+		t.Fatalf("expected zero cognitive total when not requested, got %d", resp.Totals.Cognitive)
+	}
+	for _, l := range resp.Languages {
+		if l.Cognitive != 0 {
+			t.Fatalf("expected zero cognitive for language %s, got %d", l.Name, l.Cognitive)
+		}
+		for _, f := range l.FileList {
+			if f.Cognitive != 0 {
+				t.Fatalf("expected zero cognitive for file %s, got %d", f.Filename, f.Cognitive)
+			}
+		}
+	}
+}
+
+// TestMcpAnalyzeCognitiveNoLeak guards against per-call state accumulation:
+// two consecutive analyze calls over the same input must return identical
+// cognitive numbers (cf. the ProcessConstants MCP-leak class of bug).
+func TestMcpAnalyzeCognitiveNoLeak(t *testing.T) {
+	dir := writeNestedFixture(t)
+
+	first := callAnalyze(t, dir, map[string]any{"cognitive": true})
+	second := callAnalyze(t, dir, map[string]any{"cognitive": true})
+
+	if first.Totals.Cognitive != second.Totals.Cognitive {
+		t.Fatalf("cognitive total changed across calls: %d then %d", first.Totals.Cognitive, second.Totals.Cognitive)
+	}
+	if first.Totals.Complexity != second.Totals.Complexity {
+		t.Fatalf("complexity total changed across calls: %d then %d", first.Totals.Complexity, second.Totals.Complexity)
+	}
+	if first.Totals.Code != second.Totals.Code {
+		t.Fatalf("code total changed across calls: %d then %d", first.Totals.Code, second.Totals.Code)
+	}
+}

--- a/processor/cognitive_nesting_test.go
+++ b/processor/cognitive_nesting_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+
+package processor
+
+import "testing"
+
+// These tests pin the core promise of cognitive complexity: the SAME number of
+// branch points (identical cyclomatic Complexity) must score HIGHER the more
+// deeply they are nested. Cyclomatic counts branches flatly; cognitive weights
+// each branch by 1+nesting, so shape — not just count — drives the number.
+//
+// All fixtures below contain exactly four `if`s (Complexity == 4) arranged from
+// maximally nested to maximally flat, and assert both the exact cognitive values
+// (derived from the 1+nesting rule) and the strict ordering between them.
+
+// deepChain: four ifs each nested one level deeper than the last.
+//
+//	if          nesting 1 -> +2
+//	  if        nesting 2 -> +3
+//	    if      nesting 3 -> +4
+//	      if    nesting 4 -> +5      total 14
+const deepChain = "func main() {\n" +
+	"    if a {\n" +
+	"        if b {\n" +
+	"            if c {\n" +
+	"                if d {\n" +
+	"                }\n" +
+	"            }\n" +
+	"        }\n" +
+	"    }\n" +
+	"}\n"
+
+// deNested: two independent 2-deep pairs (the user's "de-nested" example).
+//
+//	if          nesting 1 -> +2
+//	  if        nesting 2 -> +3
+//	if          nesting 1 -> +2
+//	  if        nesting 2 -> +3      total 10
+const deNested = "func main() {\n" +
+	"    if a {\n" +
+	"        if b {\n" +
+	"        }\n" +
+	"    }\n" +
+	"    if c {\n" +
+	"        if d {\n" +
+	"        }\n" +
+	"    }\n" +
+	"}\n"
+
+// flat: all four ifs as siblings at the same level.
+//
+//	if  if  if  if   each nesting 1 -> +2 each   total 8
+const flat = "func main() {\n" +
+	"    if a {\n    }\n" +
+	"    if b {\n    }\n" +
+	"    if c {\n    }\n" +
+	"    if d {\n    }\n" +
+	"}\n"
+
+// TestCognitiveDeepVsDeNestedVsFlat is the headline test: same four branches,
+// three shapes, strictly decreasing cognitive as they flatten — while the flat
+// cyclomatic Complexity stays 4 throughout.
+func TestCognitiveDeepVsDeNestedVsFlat(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	deep := countCognitive(t, "Go", deepChain)
+	mid := countCognitive(t, "Go", deNested)
+	shallow := countCognitive(t, "Go", flat)
+
+	// Same number of branch points: cyclomatic cannot tell these apart.
+	for name, job := range map[string]FileJob{"deep": deep, "deNested": mid, "flat": shallow} {
+		if job.Complexity != 4 {
+			t.Errorf("%s: expected Complexity 4 (four ifs), got %d", name, job.Complexity)
+		}
+	}
+
+	// Exact cognitive values from the 1+nesting rule.
+	if deep.Cognitive != 14 {
+		t.Errorf("deepChain Cognitive: expected 14, got %d", deep.Cognitive)
+	}
+	if mid.Cognitive != 10 {
+		t.Errorf("deNested Cognitive: expected 10, got %d", mid.Cognitive)
+	}
+	if shallow.Cognitive != 8 {
+		t.Errorf("flat Cognitive: expected 8, got %d", shallow.Cognitive)
+	}
+
+	// The relationship the metric exists to express: deeper nesting scores
+	// strictly higher, even at identical cyclomatic complexity.
+	if !(deep.Cognitive > mid.Cognitive && mid.Cognitive > shallow.Cognitive) {
+		t.Errorf("expected deep > deNested > flat, got %d, %d, %d",
+			deep.Cognitive, mid.Cognitive, shallow.Cognitive)
+	}
+}
+
+// TestCognitiveNestedHigherThanDeNested is the user's literal example, written
+// with top-level (column 0) ifs and 2-space indentation to show the ranking is
+// independent of the wrapping function and the indent unit.
+//
+//	nested:            de-nested:
+//	if                 if
+//	  if                 if
+//	    if             if
+//	      if             if
+func TestCognitiveNestedHigherThanDeNested(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	nested := "if a {\n" +
+		"  if b {\n" +
+		"    if c {\n" +
+		"      if d {\n" +
+		"      }\n" +
+		"    }\n" +
+		"  }\n" +
+		"}\n"
+
+	splitNested := "if a {\n" +
+		"  if b {\n" +
+		"  }\n" +
+		"}\n" +
+		"if c {\n" +
+		"  if d {\n" +
+		"  }\n" +
+		"}\n"
+
+	nestedJob := countCognitive(t, "Go", nested)
+	splitJob := countCognitive(t, "Go", splitNested)
+
+	if nestedJob.Complexity != splitJob.Complexity {
+		t.Fatalf("fixtures must have equal cyclomatic Complexity, got nested=%d split=%d",
+			nestedJob.Complexity, splitJob.Complexity)
+	}
+	// nested: 1+2+3+4 = 10 ; de-nested: 1+2+1+2 = 6
+	if nestedJob.Cognitive != 10 {
+		t.Errorf("nested Cognitive: expected 10, got %d", nestedJob.Cognitive)
+	}
+	if splitJob.Cognitive != 6 {
+		t.Errorf("de-nested Cognitive: expected 6, got %d", splitJob.Cognitive)
+	}
+	if nestedJob.Cognitive <= splitJob.Cognitive {
+		t.Errorf("nested (%d) should score strictly higher than de-nested (%d)",
+			nestedJob.Cognitive, splitJob.Cognitive)
+	}
+}
+
+// TestCognitiveMonotonicWithDepth: a single chain of N nested ifs. Each added
+// level of depth adds strictly more cognitive weight than the previous level did
+// (the increments grow 2,3,4,... as nesting deepens), unlike cyclomatic which
+// would add a flat 1 per branch.
+func TestCognitiveMonotonicWithDepth(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	// Build chains of depth 1..5 and record cognitive at each depth.
+	chain := func(depth int) string {
+		var b string
+		b = "func main() {\n"
+		indent := "    "
+		pad := ""
+		for i := 0; i < depth; i++ {
+			pad += indent
+			b += pad + "if x {\n"
+		}
+		for i := 0; i < depth; i++ {
+			b += pad + "}\n"
+			pad = pad[:len(pad)-len(indent)]
+		}
+		b += "}\n"
+		return b
+	}
+
+	prev := int64(-1)
+	prevDelta := int64(-1)
+	for depth := 1; depth <= 5; depth++ {
+		job := countCognitive(t, "Go", chain(depth))
+		if int64(job.Complexity) != int64(depth) {
+			t.Errorf("depth %d: expected Complexity %d, got %d", depth, depth, job.Complexity)
+		}
+		if prev >= 0 {
+			delta := job.Cognitive - prev
+			// Each deeper level contributes more than the one before it.
+			if delta <= prevDelta {
+				t.Errorf("depth %d: cognitive delta %d should exceed previous delta %d (values grow super-linearly with depth)", depth, delta, prevDelta)
+			}
+			prevDelta = delta
+		}
+		if job.Cognitive <= prev {
+			t.Errorf("depth %d: cognitive %d should exceed shallower depth's %d", depth, job.Cognitive, prev)
+		}
+		prev = job.Cognitive
+	}
+}

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -16,6 +16,23 @@ var tabularShortBreakCi = "-----------------------------------------------------
 var tabularWideBreak = "─────────────────────────────────────────────────────────────────────────────────────────────────────────────\n"
 var tabularWideBreakCi = "-------------------------------------------------------------------------------------------------------------\n"
 
+// Wider break variants matching the extra Cognitive column (11 chars wider).
+var tabularWideBreakCognitive = strings.Repeat("─", 120) + "\n"
+var tabularWideBreakCiCognitive = strings.Repeat("-", 120) + "\n"
+
+// activeComplexity returns the complexity magnitude to display and sort by: the
+// nesting-weighted Cognitive value when --cognitive is active, otherwise the
+// cyclomatic Complexity. The default tabular "Complexity" column and the
+// "complexity" sort key both follow the active metric, so --cognitive overrides
+// them in place without changing the header. Machine formats (JSON/CSV/SQL/MCP)
+// keep both fields distinct and do not use this.
+func activeComplexity(complexity, cognitive int64) int64 {
+	if Cognitive {
+		return cognitive
+	}
+	return complexity
+}
+
 func sortSummaryFiles(summary *LanguageSummary) {
 	switch SortBy {
 	case "name", "names", "language", "languages", "lang", "langs":
@@ -40,7 +57,11 @@ func sortSummaryFiles(summary *LanguageSummary) {
 		})
 	case "complexity", "complexitys", "comp":
 		slices.SortFunc(summary.Files, func(a, b *FileJob) int {
-			return cmp.Compare(b.Complexity, a.Complexity)
+			return cmp.Compare(activeComplexity(b.Complexity, b.Cognitive), activeComplexity(a.Complexity, a.Cognitive))
+		})
+	case "cognitive", "cognitives", "cog":
+		slices.SortFunc(summary.Files, func(a, b *FileJob) int {
+			return cmp.Compare(b.Cognitive, a.Cognitive)
 		})
 	default:
 		slices.SortFunc(summary.Files, func(a, b *FileJob) int {
@@ -67,7 +88,14 @@ func getTabularWideBreak() string {
 	}
 
 	if Ci {
+		if Cognitive {
+			return tabularWideBreakCiCognitive
+		}
 		return tabularWideBreakCi
+	}
+
+	if Cognitive {
+		return tabularWideBreakCognitive
 	}
 
 	return tabularWideBreak
@@ -196,6 +224,7 @@ func aggregateLanguageSummary(input chan *FileJob) []LanguageSummary {
 				Comment:    res.Comment,
 				Blank:      res.Blank,
 				Complexity: res.Complexity,
+				Cognitive:  res.Cognitive,
 				Count:      1,
 				Files:      files,
 				Bytes:      res.Bytes,
@@ -215,6 +244,7 @@ func aggregateLanguageSummary(input chan *FileJob) []LanguageSummary {
 				Comment:    tmp.Comment + res.Comment,
 				Blank:      tmp.Blank + res.Blank,
 				Complexity: tmp.Complexity + res.Complexity,
+				Cognitive:  tmp.Cognitive + res.Cognitive,
 				Count:      tmp.Count + 1,
 				Files:      files,
 				Bytes:      res.Bytes + tmp.Bytes,
@@ -272,7 +302,14 @@ func sortLanguageSummary(language []LanguageSummary) []LanguageSummary {
 		})
 	case "complexity", "complexitys":
 		slices.SortFunc(language, func(a, b LanguageSummary) int {
-			if order := cmp.Compare(b.Complexity, a.Complexity); order != 0 {
+			if order := cmp.Compare(activeComplexity(b.Complexity, b.Cognitive), activeComplexity(a.Complexity, a.Cognitive)); order != 0 {
+				return order
+			}
+			return strings.Compare(a.Name, b.Name)
+		})
+	case "cognitive", "cognitives", "cog":
+		slices.SortFunc(language, func(a, b LanguageSummary) int {
+			if order := cmp.Compare(b.Cognitive, a.Cognitive); order != 0 {
 				return order
 			}
 			return strings.Compare(a.Name, b.Name)

--- a/processor/formatters_cognitive_test.go
+++ b/processor/formatters_cognitive_test.go
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: MIT
+
+package processor
+
+import (
+	"strings"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
+// cognitiveFixtureChan returns a closed channel with two Go files whose
+// Cognitive values are known so callers can assert on aggregation.
+func cognitiveFixtureChan() chan *FileJob {
+	inputChan := make(chan *FileJob, 8)
+	inputChan <- &FileJob{
+		Language:   "Go",
+		Filename:   "aaaa.go",
+		Location:   "aaaa.go",
+		Bytes:      100,
+		Lines:      100,
+		Code:       80,
+		Comment:    10,
+		Blank:      10,
+		Complexity: 5,
+		Cognitive:  11,
+	}
+	inputChan <- &FileJob{
+		Language:   "Go",
+		Filename:   "bbbb.go",
+		Location:   "bbbb.go",
+		Bytes:      100,
+		Lines:      100,
+		Code:       80,
+		Comment:    10,
+		Blank:      10,
+		Complexity: 5,
+		Cognitive:  20,
+	}
+	close(inputChan)
+	return inputChan
+}
+
+func TestFileSummarizeLongCognitive(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	res := fileSummarizeLong(cognitiveFixtureChan())
+
+	if !strings.Contains(res, "Cognitive") {
+		t.Errorf("wide cognitive output missing Cognitive header:\n%s", res)
+	}
+	// language total and grand total are both 11 + 20 = 31
+	if !strings.Contains(res, "31") {
+		t.Errorf("wide cognitive output missing summed cognitive 31:\n%s", res)
+	}
+}
+
+func TestFileSummarizeLongCognitiveDisabledParity(t *testing.T) {
+	if Cognitive {
+		t.Fatalf("Cognitive should default to false")
+	}
+	res := fileSummarizeLong(cognitiveFixtureChan())
+
+	if strings.Contains(res, "Cognitive") {
+		t.Errorf("wide output leaked Cognitive column while disabled:\n%s", res)
+	}
+	// Break lines must stay at the original 109-rune width when disabled.
+	for _, line := range strings.Split(res, "\n") {
+		if strings.HasPrefix(line, "─") && len([]rune(line)) != 109 {
+			t.Errorf("disabled wide break width changed: got %d want 109", len([]rune(line)))
+		}
+	}
+}
+
+// TestFileSummarizeShortCognitiveOverride asserts that in the default (non-wide)
+// view --cognitive overrides the Complexity column value in place (header stays
+// "Complexity") rather than adding a column: the printed magnitude is the summed
+// Cognitive (31), not the summed Complexity (10).
+func TestFileSummarizeShortCognitiveOverride(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	res := fileSummarizeShort(cognitiveFixtureChan())
+
+	if !strings.Contains(res, "Complexity") {
+		t.Errorf("short view lost the Complexity header:\n%s", res)
+	}
+	if strings.Contains(res, "Cognitive") {
+		t.Errorf("short view should not add a Cognitive column:\n%s", res)
+	}
+	// The Go language row and Total both carry the cognitive magnitude 31,
+	// never the cyclomatic 10.
+	if !strings.Contains(res, "31") {
+		t.Errorf("short view Complexity column did not show cognitive 31:\n%s", res)
+	}
+	if strings.Contains(res, " 10\n") {
+		t.Errorf("short view still shows cyclomatic complexity 10 instead of cognitive:\n%s", res)
+	}
+}
+
+// TestFileSummarizeShortCognitiveDisabledParity asserts the default view is
+// byte-identical to before when --cognitive is off: it shows the cyclomatic
+// value and no cognitive anywhere.
+func TestFileSummarizeShortCognitiveDisabledParity(t *testing.T) {
+	if Cognitive {
+		t.Fatalf("Cognitive should default to false")
+	}
+	res := fileSummarizeShort(cognitiveFixtureChan())
+
+	if strings.Contains(res, "Cognitive") {
+		t.Errorf("short view leaked Cognitive while disabled:\n%s", res)
+	}
+	// summed cyclomatic complexity is 10; cognitive 31 must not appear
+	if !strings.Contains(res, " 10\n") {
+		t.Errorf("short view lost cyclomatic complexity 10 while disabled:\n%s", res)
+	}
+}
+
+// TestSortSummaryFilesCognitive verifies the sort-key resolution: with
+// --cognitive the "complexity" key ranks by cognitive weight, an explicit
+// "cognitive" key always ranks by cognitive, and without the flag "complexity"
+// still ranks by cyclomatic complexity.
+func TestSortSummaryFilesCognitive(t *testing.T) {
+	// a has higher cyclomatic, b has higher cognitive — so the orderings differ.
+	newSummary := func() *LanguageSummary {
+		return &LanguageSummary{Files: []*FileJob{
+			{Location: "a", Complexity: 9, Cognitive: 1},
+			{Location: "b", Complexity: 1, Cognitive: 9},
+		}}
+	}
+	prevSort := SortBy
+	defer func() { SortBy = prevSort }()
+
+	// complexity key, cognitive off → cyclomatic order (a first)
+	Cognitive = false
+	SortBy = "complexity"
+	s := newSummary()
+	sortSummaryFiles(s)
+	if s.Files[0].Location != "a" {
+		t.Errorf("complexity/off: expected a first, got %s", s.Files[0].Location)
+	}
+
+	// complexity key, cognitive on → cognitive order (b first)
+	Cognitive = true
+	defer func() { Cognitive = false }()
+	s = newSummary()
+	sortSummaryFiles(s)
+	if s.Files[0].Location != "b" {
+		t.Errorf("complexity/cognitive: expected b first, got %s", s.Files[0].Location)
+	}
+
+	// explicit cognitive key → cognitive order (b first) regardless
+	SortBy = "cognitive"
+	s = newSummary()
+	sortSummaryFiles(s)
+	if s.Files[0].Location != "b" {
+		t.Errorf("cognitive key: expected b first, got %s", s.Files[0].Location)
+	}
+}
+
+func TestToJSONCognitive(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	res := toJSON(cognitiveFixtureChan())
+
+	var langs []LanguageSummary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	if err := json.Unmarshal([]byte(res), &langs); err != nil {
+		t.Fatalf("failed to unmarshal cognitive JSON: %v", err)
+	}
+	if len(langs) != 1 {
+		t.Fatalf("expected 1 language, got %d", len(langs))
+	}
+	// round-trips to the summed cognitive value
+	if langs[0].Cognitive != 31 {
+		t.Errorf("expected language Cognitive 31, got %d", langs[0].Cognitive)
+	}
+}
+
+func TestToJSONCognitiveDisabledParity(t *testing.T) {
+	if Cognitive {
+		t.Fatalf("Cognitive should default to false")
+	}
+	// When the flag is off, bumpCognitive never runs so FileJob.Cognitive stays
+	// 0; JSON parity relies on omitempty dropping the zero value. Model that here
+	// with a zero-cognitive fixture rather than the non-zero shared one.
+	inputChan := make(chan *FileJob, 2)
+	inputChan <- &FileJob{Language: "Go", Filename: "a.go", Location: "a.go", Lines: 100, Code: 80, Complexity: 5}
+	close(inputChan)
+
+	res := toJSON(inputChan)
+
+	if strings.Contains(res, "Cognitive") {
+		t.Errorf("JSON leaked Cognitive key while disabled:\n%s", res)
+	}
+}
+
+func TestToCSVCognitive(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	res := toCSV(cognitiveFixtureChan())
+
+	lines := strings.Split(strings.TrimSpace(res), "\n")
+	if !strings.HasSuffix(lines[0], "Cognitive") {
+		t.Errorf("CSV header missing trailing Cognitive column: %q", lines[0])
+	}
+	// summed cognitive for the single Go row is 31
+	if !strings.HasSuffix(strings.TrimSpace(lines[1]), ",31") {
+		t.Errorf("CSV row missing cognitive value 31: %q", lines[1])
+	}
+}
+
+func TestToCSVCognitiveDisabledParity(t *testing.T) {
+	if Cognitive {
+		t.Fatalf("Cognitive should default to false")
+	}
+	res := toCSV(cognitiveFixtureChan())
+
+	if strings.Contains(res, "Cognitive") {
+		t.Errorf("CSV leaked Cognitive column while disabled:\n%s", res)
+	}
+}
+
+func TestToSQLCognitive(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	res := toSql(cognitiveFixtureChan())
+
+	if !strings.Contains(res, "nCognitive") {
+		t.Errorf("SQL schema missing nCognitive column:\n%s", res)
+	}
+	// each per-file insert carries its cognitive value as the final column
+	if !strings.Contains(res, ", 11);") || !strings.Contains(res, ", 20);") {
+		t.Errorf("SQL inserts missing per-file cognitive values:\n%s", res)
+	}
+}
+
+func TestToSQLCognitiveDisabledParity(t *testing.T) {
+	if Cognitive {
+		t.Fatalf("Cognitive should default to false")
+	}
+	res := toSql(cognitiveFixtureChan())
+
+	if strings.Contains(res, "Cognitive") || strings.Contains(res, "nCognitive") {
+		t.Errorf("SQL leaked Cognitive column while disabled:\n%s", res)
+	}
+}

--- a/processor/formatters_cognitive_test.go
+++ b/processor/formatters_cognitive_test.go
@@ -179,6 +179,42 @@ func TestToJSONCognitive(t *testing.T) {
 	}
 }
 
+// TestToJSONCognitiveZeroStillEmitted is the regression guard for the omitempty
+// bug: while --cognitive is active, a branch-free file (Cognitive == 0) must
+// still carry the field at both language and file level, so consumers see the
+// key on every row rather than it vanishing exactly when the value is 0.
+func TestToJSONCognitiveZeroStillEmitted(t *testing.T) {
+	Cognitive = true
+	Files = true
+	defer func() { Cognitive = false; Files = false }()
+
+	inputChan := make(chan *FileJob, 2)
+	inputChan <- &FileJob{
+		Language: "Markdown", Filename: "r.md", Location: "r.md",
+		Lines: 10, Code: 10, Complexity: 0, Cognitive: 0,
+	}
+	close(inputChan)
+
+	res := toJSON(inputChan)
+
+	// Present at language level even though the value is 0.
+	if !strings.Contains(res, `"Cognitive":0`) {
+		t.Errorf("expected zero-valued Cognitive to still be emitted while enabled:\n%s", res)
+	}
+	// And it round-trips (including the per-file entry).
+	var langs []LanguageSummary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	if err := json.Unmarshal([]byte(res), &langs); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(langs) != 1 || len(langs[0].Files) != 1 {
+		t.Fatalf("unexpected shape: %+v", langs)
+	}
+	if langs[0].Cognitive != 0 {
+		t.Errorf("language Cognitive should round-trip to 0, got %d", langs[0].Cognitive)
+	}
+}
+
 func TestToJSONCognitiveDisabledParity(t *testing.T) {
 	if Cognitive {
 		t.Fatalf("Cognitive should default to false")

--- a/processor/formatters_csv.go
+++ b/processor/formatters_csv.go
@@ -36,6 +36,9 @@ func toCSVSummary(input chan *FileJob) string {
 		"Files",
 		"ULOC",
 	}
+	if Cognitive {
+		record = append(record, "Cognitive")
+	}
 
 	b := &bytes.Buffer{}
 	w := csv.NewWriter(b)
@@ -51,6 +54,9 @@ func toCSVSummary(input chan *FileJob) string {
 		record[6] = strconv.FormatInt(result.Bytes, 10)
 		record[7] = strconv.FormatInt(result.Count, 10)
 		record[8] = strconv.Itoa(len(ulocLanguageCount[result.Name]))
+		if Cognitive {
+			record[9] = strconv.FormatInt(result.Cognitive, 10)
+		}
 		_ = w.Write(record)
 	}
 
@@ -96,9 +102,27 @@ func getCSVFilesSortFunc(sortBy string) func(a, b []string) int {
 			return cmp.Compare(i2, i1)
 		}
 	case "complexity", "complexitys":
+		// The cognitive value is appended as column 10 only when --cognitive is
+		// set; sort by the active metric so the "complexity" key follows it.
+		idx := 7
+		if Cognitive {
+			idx = 10
+		}
 		return func(a, b []string) int {
-			i1, _ := strconv.ParseInt(a[7], 10, 64)
-			i2, _ := strconv.ParseInt(b[7], 10, 64)
+			i1, _ := strconv.ParseInt(a[idx], 10, 64)
+			i2, _ := strconv.ParseInt(b[idx], 10, 64)
+			return cmp.Compare(i2, i1)
+		}
+	case "cognitive", "cognitives":
+		if !Cognitive {
+			// No cognitive column emitted without --cognitive; fall back to name.
+			return func(a, b []string) int {
+				return strings.Compare(a[2], b[2])
+			}
+		}
+		return func(a, b []string) int {
+			i1, _ := strconv.ParseInt(a[10], 10, 64)
+			i2, _ := strconv.ParseInt(b[10], 10, 64)
 			return cmp.Compare(i2, i1)
 		}
 	case "byte", "bytes":
@@ -118,7 +142,7 @@ func toCSVFiles(input chan *FileJob) string {
 	records := [][]string{}
 
 	for result := range input {
-		records = append(records, []string{
+		row := []string{
 			result.Language,
 			result.Location,
 			result.Filename,
@@ -129,12 +153,16 @@ func toCSVFiles(input chan *FileJob) string {
 			strconv.FormatInt(result.Complexity, 10),
 			strconv.FormatInt(result.Bytes, 10),
 			strconv.Itoa(result.Uloc),
-		})
+		}
+		if Cognitive {
+			row = append(row, strconv.FormatInt(result.Cognitive, 10))
+		}
+		records = append(records, row)
 	}
 
 	slices.SortFunc(records, getCSVFilesSortFunc(SortBy))
 
-	recordsEnd := [][]string{{
+	header := []string{
 		"Language",
 		"Provider",
 		"Filename",
@@ -145,7 +173,11 @@ func toCSVFiles(input chan *FileJob) string {
 		"Complexity",
 		"Bytes",
 		"ULOC",
-	}}
+	}
+	if Cognitive {
+		header = append(header, "Cognitive")
+	}
+	recordsEnd := [][]string{header}
 
 	recordsEnd = append(recordsEnd, records...)
 
@@ -161,7 +193,11 @@ func toCSVFiles(input chan *FileJob) string {
 // with the express idea of lowering memory usage, see https://github.com/boyter/scc/issues/210 for
 // the background on why this might be needed
 func toCSVStream(input chan *FileJob) string {
-	fmt.Println("Language,Provider,Filename,Lines,Code,Comments,Blanks,Complexity,Bytes,Uloc")
+	if Cognitive {
+		fmt.Println("Language,Provider,Filename,Lines,Code,Comments,Blanks,Complexity,Bytes,Uloc,Cognitive")
+	} else {
+		fmt.Println("Language,Provider,Filename,Lines,Code,Comments,Blanks,Complexity,Bytes,Uloc")
+	}
 
 	var quoteRegex = regexp.MustCompile("\"")
 
@@ -170,18 +206,34 @@ func toCSVStream(input chan *FileJob) string {
 		var location = "\"" + quoteRegex.ReplaceAllString(result.Location, "\"\"") + "\""
 		var filename = "\"" + quoteRegex.ReplaceAllString(result.Filename, "\"\"") + "\""
 
-		fmt.Printf("%s,%s,%s,%d,%d,%d,%d,%d,%d,%d\n",
-			result.Language,
-			location,
-			filename,
-			result.Lines,
-			result.Code,
-			result.Comment,
-			result.Blank,
-			result.Complexity,
-			result.Bytes,
-			result.Uloc,
-		)
+		if Cognitive {
+			fmt.Printf("%s,%s,%s,%d,%d,%d,%d,%d,%d,%d,%d\n",
+				result.Language,
+				location,
+				filename,
+				result.Lines,
+				result.Code,
+				result.Comment,
+				result.Blank,
+				result.Complexity,
+				result.Bytes,
+				result.Uloc,
+				result.Cognitive,
+			)
+		} else {
+			fmt.Printf("%s,%s,%s,%d,%d,%d,%d,%d,%d,%d\n",
+				result.Language,
+				location,
+				filename,
+				result.Lines,
+				result.Code,
+				result.Comment,
+				result.Blank,
+				result.Complexity,
+				result.Bytes,
+				result.Uloc,
+			)
+		}
 	}
 
 	return ""

--- a/processor/formatters_sql.go
+++ b/processor/formatters_sql.go
@@ -27,12 +27,21 @@ func toSqlInsert(input chan *FileJob) string {
 
 		dir, _ := filepath.Split(res.Location)
 
-		_, _ = fmt.Fprintf(str, "\ninsert into t values('%s', '%s', '%s', '%s', '%s', %d, %d, %d, %d, %d, %d);",
-			escapeSQLString(projectName),
-			escapeSQLString(res.Language),
-			escapeSQLString(res.Location),
-			escapeSQLString(dir),
-			escapeSQLString(res.Filename), res.Bytes, res.Blank, res.Comment, res.Code, res.Complexity, res.Uloc)
+		if Cognitive {
+			_, _ = fmt.Fprintf(str, "\ninsert into t values('%s', '%s', '%s', '%s', '%s', %d, %d, %d, %d, %d, %d, %d);",
+				escapeSQLString(projectName),
+				escapeSQLString(res.Language),
+				escapeSQLString(res.Location),
+				escapeSQLString(dir),
+				escapeSQLString(res.Filename), res.Bytes, res.Blank, res.Comment, res.Code, res.Complexity, res.Uloc, res.Cognitive)
+		} else {
+			_, _ = fmt.Fprintf(str, "\ninsert into t values('%s', '%s', '%s', '%s', '%s', %d, %d, %d, %d, %d, %d);",
+				escapeSQLString(projectName),
+				escapeSQLString(res.Language),
+				escapeSQLString(res.Location),
+				escapeSQLString(dir),
+				escapeSQLString(res.Filename), res.Bytes, res.Blank, res.Comment, res.Code, res.Complexity, res.Uloc)
+		}
 
 		// every 1000 files commit and start a new transaction to avoid overloading
 		if count == 1000 {
@@ -119,7 +128,12 @@ create table t        (
              nComment      integer,
              nCode         integer,
              nComplexity   integer,
-             nUloc         integer    
+             nUloc         integer    `)
+	if Cognitive {
+		str.WriteString(`,
+             nCognitive    integer    `)
+	}
+	str.WriteString(`
 );`)
 
 	str.WriteString(toSqlInsert(input))

--- a/processor/formatters_tabular.go
+++ b/processor/formatters_tabular.go
@@ -36,6 +36,12 @@ var tabularShortPercentLanguageFormatBodyNoComplexity = "Percentage %21.1f%% %10
 var tabularWideFormatHead = "%-33s %9s %9s %8s %9s %8s %10s %16s\n"
 var tabularWideFormatBody = "%-33s %9d %9d %8d %9d %8d %10d %16.2f\n"
 var tabularWideFormatFile = "%s %9d %8d %9d %8d %10d %16.2f\n"
+
+// Cognitive variants add a right-aligned "Cognitive" column after Complexity.
+// Selected only when processor.Cognitive is set so the default layout is untouched.
+var tabularWideFormatHeadCognitive = "%-33s %9s %9s %8s %9s %8s %10s %10s %16s\n"
+var tabularWideFormatBodyCognitive = "%-33s %9d %9d %8d %9d %8d %10d %10d %16.2f\n"
+var tabularWideFormatFileCognitive = "%s %9d %8d %9d %8d %10d %10d %16.2f\n"
 var tabularWideFormatFileMaxMean = "MaxLine / MeanLine %24d %9d\n"
 var wideFormatFileTruncate = 42
 var tabularWideUlocLanguageFormatBody = "(ULOC) %46d\n"
@@ -47,14 +53,18 @@ func fileSummarizeLong(input chan *FileJob) string {
 	str := &strings.Builder{}
 
 	str.WriteString(getTabularWideBreak())
-	_, _ = fmt.Fprintf(str, tabularWideFormatHead, "Language", "Files", "Lines", "Blanks", "Comments", "Code", "Complexity", "Complexity/Lines")
+	if Cognitive {
+		_, _ = fmt.Fprintf(str, tabularWideFormatHeadCognitive, "Language", "Files", "Lines", "Blanks", "Comments", "Code", "Complexity", "Cognitive", "Complexity/Lines")
+	} else {
+		_, _ = fmt.Fprintf(str, tabularWideFormatHead, "Language", "Files", "Lines", "Blanks", "Comments", "Code", "Complexity", "Complexity/Lines")
+	}
 
 	if !Files {
 		str.WriteString(getTabularWideBreak())
 	}
 
 	langs := map[string]LanguageSummary{}
-	var sumFiles, sumLines, sumCode, sumComment, sumBlank, sumComplexity, sumBytes int64 = 0, 0, 0, 0, 0, 0, 0
+	var sumFiles, sumLines, sumCode, sumComment, sumBlank, sumComplexity, sumCognitive, sumBytes int64 = 0, 0, 0, 0, 0, 0, 0, 0
 
 	for res := range input {
 		sumFiles++
@@ -63,6 +73,7 @@ func fileSummarizeLong(input chan *FileJob) string {
 		sumComment += res.Comment
 		sumBlank += res.Blank
 		sumComplexity += res.Complexity
+		sumCognitive += res.Cognitive
 		sumBytes += res.Bytes
 
 		var weightedComplexity float64
@@ -84,6 +95,7 @@ func fileSummarizeLong(input chan *FileJob) string {
 				Comment:    res.Comment,
 				Blank:      res.Blank,
 				Complexity: res.Complexity,
+				Cognitive:  res.Cognitive,
 				Count:      1,
 				Files:      files,
 				LineLength: res.LineLength,
@@ -100,6 +112,7 @@ func fileSummarizeLong(input chan *FileJob) string {
 				Comment:    tmp.Comment + res.Comment,
 				Blank:      tmp.Blank + res.Blank,
 				Complexity: tmp.Complexity + res.Complexity,
+				Cognitive:  tmp.Cognitive + res.Cognitive,
 				Count:      tmp.Count + 1,
 				Files:      files,
 				LineLength: lineLength,
@@ -130,7 +143,11 @@ func fileSummarizeLong(input chan *FileJob) string {
 			summaryWeightedComplexity = (float64(summary.Complexity) / float64(summary.Code)) * 100
 		}
 
-		_, _ = fmt.Fprintf(str, tabularWideFormatBody, trimmedName, summary.Count, summary.Lines, summary.Blank, summary.Comment, summary.Code, summary.Complexity, summaryWeightedComplexity)
+		if Cognitive {
+			_, _ = fmt.Fprintf(str, tabularWideFormatBodyCognitive, trimmedName, summary.Count, summary.Lines, summary.Blank, summary.Comment, summary.Code, summary.Complexity, summary.Cognitive, summaryWeightedComplexity)
+		} else {
+			_, _ = fmt.Fprintf(str, tabularWideFormatBody, trimmedName, summary.Count, summary.Lines, summary.Blank, summary.Comment, summary.Code, summary.Complexity, summaryWeightedComplexity)
+		}
 
 		if Percent {
 			_, _ = fmt.Fprintf(str,
@@ -169,7 +186,11 @@ func fileSummarizeLong(input chan *FileJob) string {
 				tmp := unicodeAwareTrim(res.Location, wideFormatFileTruncate)
 				tmp = unicodeAwareRightPad(tmp, 43)
 
-				_, _ = fmt.Fprintf(str, tabularWideFormatFile, tmp, res.Lines, res.Blank, res.Comment, res.Code, res.Complexity, res.WeightedComplexity)
+				if Cognitive {
+					_, _ = fmt.Fprintf(str, tabularWideFormatFileCognitive, tmp, res.Lines, res.Blank, res.Comment, res.Code, res.Complexity, res.Cognitive, res.WeightedComplexity)
+				} else {
+					_, _ = fmt.Fprintf(str, tabularWideFormatFile, tmp, res.Lines, res.Blank, res.Comment, res.Code, res.Complexity, res.WeightedComplexity)
+				}
 			}
 		}
 	}
@@ -182,7 +203,11 @@ func fileSummarizeLong(input chan *FileJob) string {
 	}
 
 	str.WriteString(getTabularWideBreak())
-	_, _ = fmt.Fprintf(str, tabularWideFormatBody, "Total", sumFiles, sumLines, sumBlank, sumComment, sumCode, sumComplexity, totalWeightedComplexity)
+	if Cognitive {
+		_, _ = fmt.Fprintf(str, tabularWideFormatBodyCognitive, "Total", sumFiles, sumLines, sumBlank, sumComment, sumCode, sumComplexity, sumCognitive, totalWeightedComplexity)
+	} else {
+		_, _ = fmt.Fprintf(str, tabularWideFormatBody, "Total", sumFiles, sumLines, sumBlank, sumComment, sumCode, sumComplexity, totalWeightedComplexity)
+	}
 	str.WriteString(getTabularWideBreak())
 
 	if UlocMode {
@@ -253,7 +278,7 @@ func fileSummarizeShort(input chan *FileJob) string {
 	}
 
 	lang := map[string]LanguageSummary{}
-	var sumFiles, sumLines, sumCode, sumComment, sumBlank, sumComplexity, sumBytes int64 = 0, 0, 0, 0, 0, 0, 0
+	var sumFiles, sumLines, sumCode, sumComment, sumBlank, sumComplexity, sumCognitive, sumBytes int64 = 0, 0, 0, 0, 0, 0, 0, 0
 
 	p := gmessage.NewPrinter(glanguage.Make(os.Getenv("LANG")))
 
@@ -264,6 +289,7 @@ func fileSummarizeShort(input chan *FileJob) string {
 		sumComment += res.Comment
 		sumBlank += res.Blank
 		sumComplexity += res.Complexity
+		sumCognitive += res.Cognitive
 		sumBytes += res.Bytes
 
 		_, ok := lang[res.Language]
@@ -279,6 +305,7 @@ func fileSummarizeShort(input chan *FileJob) string {
 				Comment:    res.Comment,
 				Blank:      res.Blank,
 				Complexity: res.Complexity,
+				Cognitive:  res.Cognitive,
 				Count:      1,
 				Files:      files,
 				LineLength: res.LineLength,
@@ -295,6 +322,7 @@ func fileSummarizeShort(input chan *FileJob) string {
 				Comment:    tmp.Comment + res.Comment,
 				Blank:      tmp.Blank + res.Blank,
 				Complexity: tmp.Complexity + res.Complexity,
+				Cognitive:  tmp.Cognitive + res.Cognitive,
 				Count:      tmp.Count + 1,
 				Files:      files,
 				LineLength: lineLength,
@@ -320,7 +348,7 @@ func fileSummarizeShort(input chan *FileJob) string {
 		trimmedName = trimNameShort(summary, trimmedName)
 
 		if !Complexity {
-			_, _ = p.Fprintf(str, tabularShortFormatBody, trimmedName, summary.Count, summary.Lines, summary.Blank, summary.Comment, summary.Code, summary.Complexity)
+			_, _ = p.Fprintf(str, tabularShortFormatBody, trimmedName, summary.Count, summary.Lines, summary.Blank, summary.Comment, summary.Code, activeComplexity(summary.Complexity, summary.Cognitive))
 		} else {
 			_, _ = p.Fprintf(str, tabularShortFormatBodyNoComplexity, trimmedName, summary.Count, summary.Lines, summary.Blank, summary.Comment, summary.Code)
 		}
@@ -334,7 +362,7 @@ func fileSummarizeShort(input chan *FileJob) string {
 					float64(summary.Blank)/float64(sumBlank)*100,
 					float64(summary.Comment)/float64(sumComment)*100,
 					float64(summary.Code)/float64(sumCode)*100,
-					float64(summary.Complexity)/float64(sumComplexity)*100,
+					float64(activeComplexity(summary.Complexity, summary.Cognitive))/float64(activeComplexity(sumComplexity, sumCognitive))*100,
 				)
 			} else {
 				_, _ = p.Fprintf(str,
@@ -369,7 +397,7 @@ func fileSummarizeShort(input chan *FileJob) string {
 
 				if !Complexity {
 					tmp = unicodeAwareRightPad(tmp, 27)
-					_, _ = p.Fprintf(str, tabularShortFormatFile, tmp, res.Lines, res.Blank, res.Comment, res.Code, res.Complexity)
+					_, _ = p.Fprintf(str, tabularShortFormatFile, tmp, res.Lines, res.Blank, res.Comment, res.Code, activeComplexity(res.Complexity, res.Cognitive))
 				} else {
 					tmp = unicodeAwareRightPad(tmp, 34)
 					_, _ = p.Fprintf(str, tabularShortFormatFileNoComplexity, tmp, res.Lines, res.Blank, res.Comment, res.Code)
@@ -398,7 +426,7 @@ func fileSummarizeShort(input chan *FileJob) string {
 
 	str.WriteString(getTabularShortBreak())
 	if !Complexity {
-		_, _ = p.Fprintf(str, tabularShortFormatBody, "Total", sumFiles, sumLines, sumBlank, sumComment, sumCode, sumComplexity)
+		_, _ = p.Fprintf(str, tabularShortFormatBody, "Total", sumFiles, sumLines, sumBlank, sumComment, sumCode, activeComplexity(sumComplexity, sumCognitive))
 	} else {
 		_, _ = p.Fprintf(str, tabularShortFormatBodyNoComplexity, "Total", sumFiles, sumLines, sumBlank, sumComment, sumCode)
 	}

--- a/processor/history.go
+++ b/processor/history.go
@@ -77,6 +77,7 @@ type HeadFile struct {
 	Path       string
 	Language   string
 	Complexity int64
+	Cognitive  int64 // nesting-weighted complexity; zero unless the Cognitive global is on
 }
 
 // HeadSnapshot is the set of files in HEAD, keyed by path.
@@ -449,6 +450,7 @@ func buildHeadSnapshot(headCommit *object.Commit, ignore *historyIgnore, cache *
 			Path:       f.Name,
 			Language:   res.language,
 			Complexity: res.complexity,
+			Cognitive:  res.cognitive,
 		}
 		return nil
 	})
@@ -688,11 +690,13 @@ func readBlob(tree *object.Tree, entry *object.TreeEntry) ([]byte, error) {
 // blob hash. ok=false means the classifier rejected the blob (binary, no
 // language); the vectors are nil in that case.
 type blobClassifyResult struct {
-	language    string
-	complexity  int64
-	lineTypes   []LineType
-	complexLine []int
-	ok          bool
+	language      string
+	complexity    int64
+	cognitive     int64 // nesting-weighted complexity; zero unless the Cognitive global is on
+	lineTypes     []LineType
+	complexLine   []int
+	cognitiveLine []int // 1-based lines that accrued cognitive weight; nil unless Cognitive is on
+	ok            bool
 }
 
 // blobClassifyCache memoises classifyHistoryBlob output keyed by blob hash so
@@ -721,8 +725,10 @@ func (c *blobClassifyCache) classify(hash plumbing.Hash, path string, blob []byt
 	if ok {
 		res.language = job.Language
 		res.complexity = job.Complexity
+		res.cognitive = job.Cognitive
 		res.lineTypes = lineTypes
 		res.complexLine = complexityLineNumbers(job)
+		res.cognitiveLine = cognitiveLineNumbers(job)
 	}
 	if c != nil {
 		c.entries[hash] = res
@@ -783,6 +789,20 @@ func complexityLineNumbers(job *FileJob) []int {
 	out := make([]int, 0)
 	for i, count := range job.ComplexityLine {
 		if count > 0 {
+			out = append(out, i+1)
+		}
+	}
+	return out
+}
+
+// cognitiveLineNumbers returns the 1-based line numbers in job that accrued
+// cognitive weight. Mirrors complexityLineNumbers for the cognitive per-line
+// array; returns an empty slice when cognitive tracking is off (CognitiveLine
+// nil), so callers get the same shape either way.
+func cognitiveLineNumbers(job *FileJob) []int {
+	out := make([]int, 0)
+	for i, weight := range job.CognitiveLine {
+		if weight > 0 {
 			out = append(out, i+1)
 		}
 	}

--- a/processor/history_cognitive_test.go
+++ b/processor/history_cognitive_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+
+package processor
+
+import (
+	"reflect"
+	"testing"
+)
+
+// cognitiveLineNumbers must report the 1-based lines that accrued cognitive
+// weight, mirroring complexityLineNumbers for a fixture with known nesting.
+func TestCognitiveLineNumbers(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	// if tokens sit on lines 4, 5 and 6.
+	content := "package nested\n" + // 1
+		"\n" + // 2
+		"func N() {\n" + // 3
+		"\tif a {\n" + // 4
+		"\t\tif b {\n" + // 5
+		"\t\t\tif c {\n" + // 6
+		"\t\t\t}\n" + // 7
+		"\t\t}\n" + // 8
+		"\t}\n" + // 9
+		"}\n" // 10
+
+	job := countCognitiveLines(t, "Go", content)
+
+	got := cognitiveLineNumbers(&job)
+	want := []int{4, 5, 6}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("cognitiveLineNumbers = %v, want %v (CognitiveLine %v)", got, want, job.CognitiveLine)
+	}
+
+	// With Cognitive off the array is nil, so the helper returns an empty slice.
+	Cognitive = false
+	off := countCognitiveLines(t, "Go", content)
+	if n := len(cognitiveLineNumbers(&off)); n != 0 {
+		t.Errorf("cognitiveLineNumbers should be empty when Cognitive off, got %d entries", n)
+	}
+	Cognitive = true
+}
+
+// A nested-heavy file must outrank a flat file with higher cyclomatic
+// complexity and equal change frequency once cognitive weighting is on; the
+// default (flat) weighting ranks them the other way around.
+func TestHotspotsCognitiveRankingFlips(t *testing.T) {
+	saveDepth, saveFormat := HistoryDepth, Format
+	HistoryDepth, Format = 100, "tabular"
+	t.Cleanup(func() { HistoryDepth, Format = saveDepth, saveFormat })
+
+	// flat.go: 4 flat ifs   -> Complexity 4, Cognitive 8 (each if at nesting 1)
+	// nested.go: 3 nested ifs -> Complexity 3, Cognitive 9 (2+3+4)
+	// Both files are touched in every commit, so change frequency is identical.
+	flatFinal := "package flat\n\nfunc F() {\n" +
+		"\tif a {\n\t}\n\tif b {\n\t}\n\tif c {\n\t}\n\tif d {\n\t}\n}\n"
+	nestedFinal := "package nested\n\nfunc N() {\n" +
+		"\tif a {\n\t\tif b {\n\t\t\tif c {\n\t\t\t}\n\t\t}\n\t}\n}\n"
+
+	dir := makeFixtureRepo(t, []map[string]string{
+		{
+			"flat.go":   "package flat\n\nfunc F() {}\n",
+			"nested.go": "package nested\n\nfunc N() {}\n",
+		},
+		{
+			"flat.go":   "package flat\n\nfunc F() {\n\tif a {\n\t}\n}\n",
+			"nested.go": "package nested\n\nfunc N() {\n\tif a {\n\t\tif b {\n\t\t}\n\t}\n}\n",
+		},
+		{
+			"flat.go":   flatFinal,
+			"nested.go": nestedFinal,
+		},
+	})
+
+	rankOf := func(recs []hotspotsRecord, file string) int {
+		for i, r := range recs {
+			if r.File == file {
+				return i
+			}
+		}
+		return -1
+	}
+
+	// Default (flat cyclomatic) weighting: flat.go (Complexity 4) outranks
+	// nested.go (Complexity 3) at equal change frequency.
+	if Cognitive {
+		t.Fatalf("Cognitive should default to false")
+	}
+	flatObs := newHotspotsObserver()
+	if _, err := runHistory(dir, flatObs); err != nil {
+		t.Fatalf("runHistory (flat): %v", err)
+	}
+	if got := rankOf(flatObs.records, "flat.go"); got != 0 {
+		t.Fatalf("under flat weighting flat.go rank = %d, want 0 (records %v)", got, flatObs.records)
+	}
+	if rankOf(flatObs.records, "flat.go") >= rankOf(flatObs.records, "nested.go") {
+		t.Fatalf("under flat weighting flat.go should outrank nested.go")
+	}
+
+	// Cognitive weighting: nested.go (Cognitive 9) outranks flat.go (Cognitive 8).
+	Cognitive = true
+	defer func() { Cognitive = false }()
+	cogObs := newHotspotsObserver()
+	if _, err := runHistory(dir, cogObs); err != nil {
+		t.Fatalf("runHistory (cognitive): %v", err)
+	}
+	if got := rankOf(cogObs.records, "nested.go"); got != 0 {
+		t.Fatalf("under cognitive weighting nested.go rank = %d, want 0 (records %v)", got, cogObs.records)
+	}
+	if rankOf(cogObs.records, "nested.go") >= rankOf(cogObs.records, "flat.go") {
+		t.Fatalf("under cognitive weighting nested.go should outrank flat.go")
+	}
+
+	// Sanity: the cognitive magnitudes are what we expect, and the Complexity
+	// column still reports cyclomatic complexity (unchanged output).
+	nested := findRecord(cogObs.records, "nested.go")
+	flat := findRecord(cogObs.records, "flat.go")
+	if nested.Cognitive != 9 || flat.Cognitive != 8 {
+		t.Errorf("cognitive magnitudes: nested=%d (want 9) flat=%d (want 8)", nested.Cognitive, flat.Cognitive)
+	}
+	if nested.Complexity != 3 || flat.Complexity != 4 {
+		t.Errorf("complexity column changed: nested=%d (want 3) flat=%d (want 4)", nested.Complexity, flat.Complexity)
+	}
+}
+
+func findRecord(recs []hotspotsRecord, file string) hotspotsRecord {
+	for _, r := range recs {
+		if r.File == file {
+			return r
+		}
+	}
+	return hotspotsRecord{}
+}

--- a/processor/history_hotspots.go
+++ b/processor/history_hotspots.go
@@ -60,6 +60,7 @@ type hotspotsRecord struct {
 	File         string
 	Language     string
 	Complexity   int64
+	Cognitive    int64 // nesting-weighted complexity; drives Score when Cognitive is enabled
 	Commits      int
 	LinesChanged int64
 	Authors      map[authorID]struct{}
@@ -140,9 +141,18 @@ func (o *hotspotsObserver) Finalise(window HistoryWindow, head HeadSnapshot) {
 		}
 		rec.Language = hf.Language
 		rec.Complexity = hf.Complexity
+		rec.Cognitive = hf.Cognitive
 		o.totalRaw++
 
-		score := float64(rec.Complexity) * float64(rec.Commits)
+		// When cognitive complexity is enabled, rank by nesting-weighted
+		// magnitude so deeply-nested churned code outscores flat branch-heavy
+		// code with the same cyclomatic count. Default (flat) weighting is
+		// unchanged.
+		magnitude := rec.Complexity
+		if Cognitive {
+			magnitude = rec.Cognitive
+		}
+		score := float64(magnitude) * float64(rec.Commits)
 		rec.Score = score
 	}
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -68,6 +68,9 @@ var IgnoreGenerated = false
 // Complexity toggles complexity calculation
 var Complexity = false
 
+// Cognitive toggles cognitive (nesting-weighted) complexity calculation
+var Cognitive = false
+
 // More enables wider output with more information in formatter
 var More = false
 
@@ -831,6 +834,15 @@ func processFlags() {
 	// If complexity was disabled via --no-complexity, force it back on.
 	if Locomo && Complexity {
 		Complexity = false
+	}
+
+	// Cognitive complexity is derived from the complexity tokens, so it needs
+	// complexity counting enabled. Complexity is a disable switch, so force it
+	// off (i.e. enable counting) even when --no-complexity was passed; cognitive
+	// wins. Warn only when the user explicitly asked for both.
+	if Cognitive && Complexity {
+		Complexity = false
+		printWarn("--no-complexity ignored because --cognitive requires complexity counting")
 	}
 
 	printDebugF("Average Wage: %d", AverageWage)

--- a/processor/structs.go
+++ b/processor/structs.go
@@ -8,7 +8,14 @@ import (
 	"regexp"
 	"slices"
 	"sync"
+
+	jsoniter "github.com/json-iterator/go"
 )
+
+// cognitiveJSON is the marshaler used by the FileJob / LanguageSummary
+// MarshalJSON hooks. Matched to the one formatters_json.go uses so nested
+// marshaling produces byte-identical output.
+var cognitiveJSON = jsoniter.ConfigCompatibleWithStandardLibrary
 
 // Used by trie structure to store the types
 const (
@@ -124,7 +131,7 @@ type FileJob struct {
 	Comment              int64
 	Blank                int64
 	Complexity           int64
-	Cognitive            int64   `json:",omitempty"` // nesting-weighted complexity; populated only when Cognitive is enabled
+	Cognitive            int64   // nesting-weighted complexity; JSON emission is gated on the Cognitive global via MarshalJSON
 	ComplexityLine       []int64 `json:"-"`
 	CognitiveLine        []int64 `json:"-"` // per-line cognitive weight; populated only when TrackComplexityLines and Cognitive are both enabled
 	WeightedComplexity   float64
@@ -140,6 +147,27 @@ type FileJob struct {
 	ContentByteType      []byte `json:"-"` // Per-byte classification, allocated by CountStats when ClassifyContent is true
 	TrackComplexityLines bool   `json:"-"` // When true, CountStats populates ComplexityLine
 	cognitiveNesting     int    // transient per-line nesting level used during CountStats when Cognitive is enabled
+}
+
+// MarshalJSON emits FileJob with the Cognitive field present (even when 0) while
+// the Cognitive global is on, and omitted entirely when it is off. A static
+// `omitempty` tag cannot express this because it would also drop a legitimately
+// zero cognitive value on a branch-free file while the metric is active. The
+// unexported alias type carries the same field tags but none of the methods, so
+// marshaling it does not recurse.
+func (fileJob *FileJob) MarshalJSON() ([]byte, error) {
+	type alias FileJob
+	if Cognitive {
+		return cognitiveJSON.Marshal((*alias)(fileJob))
+	}
+	// Shadow the promoted Cognitive with a zero-valued omitempty field of the
+	// same JSON name: the shallower field wins the name, then omitempty drops
+	// it, so the key is absent. (A json:"-" shadow would be removed before
+	// conflict resolution, letting the embedded field resurface.)
+	return cognitiveJSON.Marshal(struct {
+		*alias
+		Cognitive int64 `json:"Cognitive,omitempty"`
+	}{alias: (*alias)(fileJob)})
 }
 
 // FilterContentByType returns a copy of Content with bytes not matching any of
@@ -176,7 +204,7 @@ type LanguageSummary struct {
 	Comment            int64
 	Blank              int64
 	Complexity         int64
-	Cognitive          int64 `json:",omitempty"` // populated/emitted only when Cognitive is enabled
+	Cognitive          int64 // nesting-weighted complexity; JSON emission is gated on the Cognitive global via MarshalJSON
 	Count              int64
 	WeightedComplexity float64
 	Files              []*FileJob
@@ -189,6 +217,20 @@ type LanguageSummary struct {
 	ComplexityPercent  *float64 `json:",omitempty"`
 	BytePercent        *float64 `json:",omitempty"`
 	FilePercent        *float64 `json:",omitempty"`
+}
+
+// MarshalJSON gates the language-level Cognitive field on the Cognitive global,
+// mirroring FileJob.MarshalJSON: present (even at 0) when the metric is on,
+// omitted when off. See FileJob.MarshalJSON for the rationale.
+func (l LanguageSummary) MarshalJSON() ([]byte, error) {
+	type alias LanguageSummary
+	if Cognitive {
+		return cognitiveJSON.Marshal(alias(l))
+	}
+	return cognitiveJSON.Marshal(struct {
+		alias
+		Cognitive int64 `json:"Cognitive,omitempty"`
+	}{alias: alias(l)})
 }
 
 // OpenClose is used to hold an open/close pair for matching such as multi line comments

--- a/processor/structs.go
+++ b/processor/structs.go
@@ -124,7 +124,9 @@ type FileJob struct {
 	Comment              int64
 	Blank                int64
 	Complexity           int64
+	Cognitive            int64   `json:",omitempty"` // nesting-weighted complexity; populated only when Cognitive is enabled
 	ComplexityLine       []int64 `json:"-"`
+	CognitiveLine        []int64 `json:"-"` // per-line cognitive weight; populated only when TrackComplexityLines and Cognitive are both enabled
 	WeightedComplexity   float64
 	Hash                 hash.Hash
 	Callback             FileJobCallback `json:"-"`
@@ -137,6 +139,7 @@ type FileJob struct {
 	ClassifyContent      bool   `json:"-"` // When true, CountStats populates ContentByteType
 	ContentByteType      []byte `json:"-"` // Per-byte classification, allocated by CountStats when ClassifyContent is true
 	TrackComplexityLines bool   `json:"-"` // When true, CountStats populates ComplexityLine
+	cognitiveNesting     int    // transient per-line nesting level used during CountStats when Cognitive is enabled
 }
 
 // FilterContentByType returns a copy of Content with bytes not matching any of
@@ -173,6 +176,7 @@ type LanguageSummary struct {
 	Comment            int64
 	Blank              int64
 	Complexity         int64
+	Cognitive          int64 `json:",omitempty"` // populated/emitted only when Cognitive is enabled
 	Count              int64
 	WeightedComplexity float64
 	Files              []*FileJob

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -154,6 +154,7 @@ func countComplexityPostfix(fileJob *FileJob, index, offsetJump int, postfixExcl
 
 	fileJob.Complexity++
 	fileJob.bumpComplexityLine()
+	fileJob.bumpCognitive()
 }
 
 // bumpComplexityLine adds one complexity tick to the line currently being
@@ -162,6 +163,19 @@ func countComplexityPostfix(fileJob *FileJob, index, offsetJump int, postfixExcl
 func (fileJob *FileJob) bumpComplexityLine() {
 	if n := len(fileJob.ComplexityLine); n > 0 {
 		fileJob.ComplexityLine[n-1]++
+	}
+}
+
+// bumpCognitive weights a single complexity token by the nesting level of the
+// line it appears on. An approximation of nested complexity, but with almost
+// no calculation overhead.
+func (fileJob *FileJob) bumpCognitive() {
+	if Cognitive {
+		weight := 1 + int64(fileJob.cognitiveNesting)
+		fileJob.Cognitive += weight
+		if n := len(fileJob.CognitiveLine); n > 0 {
+			fileJob.CognitiveLine[n-1] += weight
+		}
 	}
 }
 
@@ -365,6 +379,7 @@ func codeState(
 				if index == 0 || !isIdentifierContinue(fileJob.Content[index-1]) {
 					fileJob.Complexity++
 					fileJob.bumpComplexityLine()
+					fileJob.bumpCognitive()
 				}
 				// Skip past the matched token so a shorter token overlapping it
 				// (e.g. 為是 inside 恆為是) is not also counted. See #466.
@@ -479,6 +494,7 @@ func blankState(
 		if index == 0 || !isIdentifierContinue(fileJob.Content[index-1]) {
 			fileJob.Complexity++
 			fileJob.bumpComplexityLine()
+			fileJob.bumpCognitive()
 		}
 		// Skip past the matched token so a shorter token overlapping it
 		// (e.g. 為是 inside 恆為是) is not also counted. See #466.
@@ -579,13 +595,39 @@ func CountStats(fileJob *FileJob) {
 	ignoreEscape := false
 	if fileJob.TrackComplexityLines {
 		fileJob.ComplexityLine = append(fileJob.ComplexityLine, 0)
+		if Cognitive {
+			fileJob.CognitiveLine = append(fileJob.CognitiveLine, 0)
+		}
 	}
 
 	if fileJob.ClassifyContent {
 		fileJob.ContentByteType = make([]byte, fileJob.Bytes)
 	}
 
-	for index := checkBomSkip(fileJob); index < int(fileJob.Bytes); index++ {
+	bomSkip := checkBomSkip(fileJob)
+
+	// We want to track cognitive complexity nesting. Cognitive complexity
+	// means we assign higher complexity to nested swtich conditions, so
+	//
+	// if something:
+	//     if otherthing:
+	//
+	// would be assigned a higher complexity than
+	//
+	// if something:
+	// if otherthing:
+	//
+	// because the nested if requires more mental overhead. To do this we need to track
+	// how nested each condition is when we hit it. We do this by counting the number of
+	// whitespace characters are in front of the condition.
+	// This is an appoximation, true for languages like Python, and probably true for anything
+	// else. However, the benefit of this approach is that it's almost free from a CPU point of view
+	// and the increase in spotting complex code, is genuinely useful.
+	var indentStack []int
+	lineStart := bomSkip
+	needIndent := true
+
+	for index := bomSkip; index < int(fileJob.Bytes); index++ {
 		if fileJob.ContentByteType != nil {
 			fileJob.ContentByteType[index] = stateToByteType(currentState)
 		}
@@ -595,6 +637,29 @@ func CountStats(fileJob *FileJob) {
 		// changing anything in here and profile/measure afterwards!
 		// NB that the order of the if statements matters and has been set to what in benchmarks is most efficient
 		if !isWhitespace(fileJob.Content[index]) {
+
+			// At the first non-whitespace byte of a code-bearing line, update the
+			// indent stack so complexity tokens on this line are weighted by their
+			// nesting depth. Lines that begin a comment must not move the stack;
+			// lines inside a multiline comment/string never reach here in a
+			// blank-derived state so they are excluded automatically.
+			if Cognitive && needIndent && (currentState == SBlank || currentState == SMulticommentBlank) {
+				if tokenType, _, _ := langFeatures.Tokens.Match(fileJob.Content[index:]); tokenType != TSlcomment && tokenType != TMlcomment {
+					indent := index - lineStart
+					for len(indentStack) > 0 && indent < indentStack[len(indentStack)-1] {
+						indentStack = indentStack[:len(indentStack)-1]
+					}
+					if len(indentStack) == 0 || indent > indentStack[len(indentStack)-1] {
+						indentStack = append(indentStack, indent)
+					}
+					nesting := len(indentStack) - 1
+					if nesting < 0 {
+						nesting = 0
+					}
+					fileJob.cognitiveNesting = nesting
+					needIndent = false
+				}
+			}
 
 			switch currentState {
 			case SCode:
@@ -655,8 +720,15 @@ func CountStats(fileJob *FileJob) {
 		// we are currently in
 		if fileJob.Content[index] == '\n' || index >= endPoint {
 			fileJob.Lines++
+			if Cognitive {
+				lineStart = index + 1
+				needIndent = true
+			}
 			if fileJob.TrackComplexityLines {
 				fileJob.ComplexityLine = append(fileJob.ComplexityLine, 0)
+				if Cognitive {
+					fileJob.CognitiveLine = append(fileJob.CognitiveLine, 0)
+				}
 			}
 
 			if NoLarge && fileJob.Lines >= LargeLineCount {
@@ -754,6 +826,9 @@ func CountStats(fileJob *FileJob) {
 
 	if fileJob.TrackComplexityLines {
 		fileJob.ComplexityLine = fileJob.ComplexityLine[:fileJob.Lines]
+		if Cognitive {
+			fileJob.CognitiveLine = fileJob.CognitiveLine[:fileJob.Lines]
+		}
 	}
 }
 

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -606,23 +606,23 @@ func CountStats(fileJob *FileJob) {
 
 	bomSkip := checkBomSkip(fileJob)
 
-	// We want to track cognitive complexity nesting. Cognitive complexity
-	// means we assign higher complexity to nested swtich conditions, so
+	//We want to track cognitive complexity nesting. Cognitive complexity
+	//means we assign higher complexity to nested branch conditions, so
 	//
-	// if something:
-	//     if otherthing:
+	//if something:
+	//    if otherthing:
 	//
-	// would be assigned a higher complexity than
+	//would be assigned a higher complexity than
 	//
-	// if something:
-	// if otherthing:
+	//if something:
+	//if otherthing:
 	//
-	// because the nested if requires more mental overhead. To do this we need to track
-	// how nested each condition is when we hit it. We do this by counting the number of
-	// whitespace characters are in front of the condition.
-	// This is an appoximation, true for languages like Python, and probably true for anything
-	// else. However, the benefit of this approach is that it's almost free from a CPU point of view
-	// and the increase in spotting complex code, is genuinely useful.
+	//because the nested if requires more mental overhead. To do this we need to track
+	//how nested each condition is when we hit it. We do this by counting the number of
+	//whitespace characters are in front of the condition.
+	//This is an appoximation, true for languages like Python, and probably true for anything
+	//else. However, the benefit of this approach is that it's almost free from a CPU point of view
+	//and the increase in spotting complex code, is genuinely useful.
 	var indentStack []int
 	lineStart := bomSkip
 	needIndent := true

--- a/processor/workers_cognitive_test.go
+++ b/processor/workers_cognitive_test.go
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: MIT
+
+package processor
+
+import "testing"
+
+// countCognitive runs CountStats over content for the given language with the
+// Cognitive global enabled and returns the resulting FileJob so callers can
+// assert on both Complexity and Cognitive.
+func countCognitive(t *testing.T, language, content string) FileJob {
+	t.Helper()
+	ProcessConstants()
+
+	fileJob := FileJob{Language: language}
+	fileJob.SetContent(content)
+	CountStats(&fileJob)
+	return fileJob
+}
+
+// countCognitiveLines runs CountStats with both Cognitive and per-line tracking
+// on, so callers can assert on the CognitiveLine array as well as the whole-file
+// tally.
+func countCognitiveLines(t *testing.T, language, content string) FileJob {
+	t.Helper()
+	ProcessConstants()
+
+	fileJob := FileJob{Language: language, TrackComplexityLines: true}
+	fileJob.SetContent(content)
+	CountStats(&fileJob)
+	return fileJob
+}
+
+func sumInt64(xs []int64) int64 {
+	var total int64
+	for _, x := range xs {
+		total += x
+	}
+	return total
+}
+
+// The per-line array must total to the whole-file Cognitive value, for flat and
+// nested files alike.
+func TestCognitiveLineSumEqualsCognitive(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	cases := map[string]string{
+		"flat": "func main() {\n" +
+			"    if a {\n    }\n    if b {\n    }\n    if c {\n    }\n}\n",
+		"nested": "func main() {\n" +
+			"    if a {\n        if b {\n            if c {\n            }\n        }\n    }\n}\n",
+		"no trailing newline": "func main() {\n    if a {\n        if b {\n        }\n    }\n}",
+	}
+
+	for name, content := range cases {
+		job := countCognitiveLines(t, "Go", content)
+		if got := sumInt64(job.CognitiveLine); got != job.Cognitive {
+			t.Errorf("case %q: sum(CognitiveLine)=%d, want Cognitive=%d (line array %v)", name, got, job.Cognitive, job.CognitiveLine)
+		}
+		if job.Cognitive == 0 {
+			t.Errorf("case %q: expected non-zero Cognitive", name)
+		}
+	}
+}
+
+// CognitiveLine is trimmed to exactly Lines entries, the same invariant
+// ComplexityLine holds, with and without a trailing newline.
+func TestCognitiveLineLengthEqualsLines(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	cases := map[string]string{
+		"trailing newline":    "func main() {\n    if a {\n    }\n}\n",
+		"no trailing newline": "func main() {\n    if a {\n    }\n}",
+	}
+
+	for name, content := range cases {
+		job := countCognitiveLines(t, "Go", content)
+		if int64(len(job.CognitiveLine)) != job.Lines {
+			t.Errorf("case %q: len(CognitiveLine)=%d, want Lines=%d", name, len(job.CognitiveLine), job.Lines)
+		}
+		// Must stay in lock-step with ComplexityLine's length.
+		if len(job.CognitiveLine) != len(job.ComplexityLine) {
+			t.Errorf("case %q: len(CognitiveLine)=%d != len(ComplexityLine)=%d", name, len(job.CognitiveLine), len(job.ComplexityLine))
+		}
+	}
+}
+
+// When Cognitive is off, CognitiveLine stays nil even with per-line tracking on,
+// exactly as ComplexityLine stays empty when its own tracking is off.
+func TestCognitiveLineEmptyWhenDisabled(t *testing.T) {
+	if Cognitive {
+		t.Fatalf("Cognitive should default to false")
+	}
+	job := countCognitiveLines(t, "Go", "func main() {\n    if a {\n    }\n}\n")
+
+	if job.CognitiveLine != nil {
+		t.Errorf("CognitiveLine should be nil when Cognitive disabled, got %v", job.CognitiveLine)
+	}
+	// ComplexityLine is still populated because TrackComplexityLines is on.
+	if len(job.ComplexityLine) == 0 {
+		t.Errorf("ComplexityLine should still be populated when only Cognitive is off")
+	}
+}
+
+func TestCognitiveFlatVsNested(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	flat := "func main() {\n" +
+		"    if a {\n" +
+		"    }\n" +
+		"    if b {\n" +
+		"    }\n" +
+		"    if c {\n" +
+		"    }\n" +
+		"}\n"
+
+	nested := "func main() {\n" +
+		"    if a {\n" +
+		"        if b {\n" +
+		"            if c {\n" +
+		"            }\n" +
+		"        }\n" +
+		"    }\n" +
+		"}\n"
+
+	flatJob := countCognitive(t, "Go", flat)
+	nestedJob := countCognitive(t, "Go", nested)
+
+	if flatJob.Complexity != 3 {
+		t.Errorf("flat Complexity: expected 3 got %d", flatJob.Complexity)
+	}
+	if nestedJob.Complexity != 3 {
+		t.Errorf("nested Complexity: expected 3 got %d", nestedJob.Complexity)
+	}
+	if flatJob.Complexity != nestedJob.Complexity {
+		t.Errorf("flat and nested should have equal Complexity, got %d vs %d", flatJob.Complexity, nestedJob.Complexity)
+	}
+
+	if flatJob.Cognitive != 6 {
+		t.Errorf("flat Cognitive: expected 6 got %d", flatJob.Cognitive)
+	}
+	if nestedJob.Cognitive != 9 {
+		t.Errorf("nested Cognitive: expected 9 got %d", nestedJob.Cognitive)
+	}
+	if nestedJob.Cognitive <= flatJob.Cognitive {
+		t.Errorf("nested Cognitive (%d) should be strictly greater than flat (%d)", nestedJob.Cognitive, flatJob.Cognitive)
+	}
+}
+
+func TestCognitiveDisabledByDefault(t *testing.T) {
+	if Cognitive {
+		t.Fatalf("Cognitive should default to false")
+	}
+	ProcessConstants()
+
+	nested := "func main() {\n" +
+		"    if a {\n" +
+		"        if b {\n" +
+		"            if c {\n" +
+		"            }\n" +
+		"        }\n" +
+		"    }\n" +
+		"}\n"
+
+	fileJob := FileJob{Language: "Go"}
+	fileJob.SetContent(nested)
+	CountStats(&fileJob)
+
+	if fileJob.Cognitive != 0 {
+		t.Errorf("Cognitive should be 0 when disabled, got %d", fileJob.Cognitive)
+	}
+	// Complexity must be unaffected by the cognitive machinery.
+	if fileJob.Complexity != 3 {
+		t.Errorf("Complexity should be 3 when Cognitive disabled, got %d", fileJob.Complexity)
+	}
+}
+
+func TestCognitiveTabsAndSpacesEquivalent(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	spaces := "func main() {\n" +
+		"    if a {\n" +
+		"        if b {\n" +
+		"            if c {\n" +
+		"            }\n" +
+		"        }\n" +
+		"    }\n" +
+		"}\n"
+
+	tabs := "func main() {\n" +
+		"\tif a {\n" +
+		"\t\tif b {\n" +
+		"\t\t\tif c {\n" +
+		"\t\t\t}\n" +
+		"\t\t}\n" +
+		"\t}\n" +
+		"}\n"
+
+	spacesJob := countCognitive(t, "Go", spaces)
+	tabsJob := countCognitive(t, "Go", tabs)
+
+	if spacesJob.Cognitive != tabsJob.Cognitive {
+		t.Errorf("tabs and spaces should yield equal Cognitive, got spaces=%d tabs=%d", spacesJob.Cognitive, tabsJob.Cognitive)
+	}
+	if tabsJob.Cognitive != 9 {
+		t.Errorf("tabs Cognitive: expected 9 got %d", tabsJob.Cognitive)
+	}
+}
+
+func TestCognitiveCommentAndBlankDoNotAffectNesting(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	plain := "func main() {\n" +
+		"    if a {\n" +
+		"    }\n" +
+		"    if b {\n" +
+		"    }\n" +
+		"}\n"
+
+	withNoise := "func main() {\n" +
+		"    if a {\n" +
+		"    }\n" +
+		"\n" +
+		"            // deeply indented comment\n" +
+		"    if b {\n" +
+		"    }\n" +
+		"}\n"
+
+	plainJob := countCognitive(t, "Go", plain)
+	noiseJob := countCognitive(t, "Go", withNoise)
+
+	if plainJob.Cognitive != 4 {
+		t.Errorf("plain Cognitive: expected 4 got %d", plainJob.Cognitive)
+	}
+	if noiseJob.Cognitive != plainJob.Cognitive {
+		t.Errorf("comment/blank lines changed Cognitive: plain=%d noise=%d", plainJob.Cognitive, noiseJob.Cognitive)
+	}
+	if noiseJob.Complexity != plainJob.Complexity {
+		t.Errorf("comment/blank lines changed Complexity: plain=%d noise=%d", plainJob.Complexity, noiseJob.Complexity)
+	}
+}
+
+func TestCognitiveStringsDoNotAffectNesting(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	// The `if fake` sits inside a multiline raw string: it must contribute no
+	// complexity and its deep indent must not push the indent stack.
+	content := "func main() {\n" +
+		"    s := `\n" +
+		"            if fake {\n" +
+		"    `\n" +
+		"    if a {\n" +
+		"    }\n" +
+		"}\n"
+
+	job := countCognitive(t, "Go", content)
+
+	if job.Complexity != 1 {
+		t.Errorf("Complexity: expected 1 (string contents ignored) got %d", job.Complexity)
+	}
+	if job.Cognitive != 2 {
+		t.Errorf("Cognitive: expected 2 (real if at nesting 1) got %d", job.Cognitive)
+	}
+}
+
+func TestCognitivePostfixLanguage(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	// Rust uses `?` as a postfix complexity token, routed via
+	// countComplexityPostfix. Each ? and the if must accrue weighted cognitive.
+	content := "fn main() {\n" +
+		"    let x = foo()?;\n" +
+		"    if a {\n" +
+		"        let y = bar()?;\n" +
+		"    }\n" +
+		"}\n"
+
+	job := countCognitive(t, "Rust", content)
+
+	// two `?` postfix tokens + one `if`
+	if job.Complexity != 3 {
+		t.Errorf("Complexity: expected 3 got %d", job.Complexity)
+	}
+	// foo()? at nesting 1 (+2), if at nesting 1 (+2), bar()? at nesting 2 (+3)
+	if job.Cognitive != 7 {
+		t.Errorf("Cognitive: expected 7 got %d", job.Cognitive)
+	}
+	if job.Cognitive == 0 {
+		t.Errorf("postfix language should accrue Cognitive")
+	}
+}
+
+func TestCognitiveNoPanicPathological(t *testing.T) {
+	Cognitive = true
+	defer func() { Cognitive = false }()
+
+	cases := map[string]string{
+		"empty":            "",
+		"single newline":   "\n",
+		"all whitespace":   "   \t  \n   \n\t\t",
+		"no trailing nl":   "func main() {\n    if a {\n    }\n}",
+		"starts indented":  "        if a {\n        }\n",
+		"only indentation": "\t\t\t\t",
+	}
+
+	for name, content := range cases {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("case %q panicked: %v", name, r)
+				}
+			}()
+			job := countCognitive(t, "Go", content)
+			if job.Cognitive < 0 {
+				t.Errorf("case %q produced negative Cognitive %d", name, job.Cognitive)
+			}
+		}()
+	}
+}

--- a/test-all.sh
+++ b/test-all.sh
@@ -465,15 +465,15 @@ else
 fi
 rm -rf "$tmp"
 
-# project .scc discovery + CLI precedence (global < project < CLI)
+# project .sccconfig discovery + CLI precedence (global < project < CLI)
 tmp=$(mktemp -d)
 echo 'package main' > "$tmp/main.go"
-printf -- '--format csv\n' > "$tmp/.scc"
+printf -- '--format csv\n' > "$tmp/.sccconfig"
 if (cd "$tmp" && "$SCC_BIN") | grep -q "Language,Lines,Code"; then
-    echo -e "${GREEN}PASSED project .scc discovery test"
+    echo -e "${GREEN}PASSED project .sccconfig discovery test"
 else
     echo -e "${RED}======================================================="
-    echo -e "FAILED project ./.scc should be auto-discovered and applied"
+    echo -e "FAILED project ./.sccconfig should be auto-discovered and applied"
     echo -e "=======================================================${NC}"
     rm -rf "$tmp"
     exit


### PR DESCRIPTION
WIP adding cognative complexity... well an approximation of it.

We want to track cognitive complexity nesting. Cognitive complexity
means we assign higher complexity to nested branch conditions, so

```
if something:
	  if otherthing:
```

would be assigned a higher complexity than

```
if something:
if otherthing:
```

because the nested if requires more mental overhead. To do this we need to track
how nested each condition is when we hit it. We do this by counting the number of
whitespace characters are in front of the condition.
This is an appoximation, true for languages like Python, and probably true for anything
else. However, the benefit of this approach is that it's almost free from a CPU point of view
and the increase in spotting complex code, is genuinely useful.