### PR TITLE
Limit Docker container permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Go to the directory you want to run scc from.
 Run the command below to run the latest release of scc on your current working directory:
 
 ```bash
-docker run --rm -it -v "$PWD:/pwd"  ghcr.io/boyter/scc:master scc /pwd
+docker run --rm -it -v "$PWD:/pwd:ro" --network none ghcr.io/boyter/scc:master scc /pwd
 ```
 
 #### Manual


### PR DESCRIPTION
Use `:ro` on the volume and `--network none` so the container can't write to disk or make any network requests. Users can turn this off if they need something advanced, but it works for me for default invocations.