### PR TITLE
feat: add F# string literals so (* inside a string is not a comment opener

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -2381,7 +2381,22 @@
     "extensions": ["fs", "fsi", "fsx", "fsscript"],
     "line_comment": ["//"],
     "multi_line": [["(*", "*)"]],
-    "quotes": []
+    "quotes": [
+      {
+        "end": "\"",
+        "start": "\""
+      },
+      {
+        "end": "\"",
+        "ignoreEscape": true,
+        "start": "@\""
+      },
+      {
+        "end": "\"\"\"",
+        "ignoreEscape": true,
+        "start": "\"\"\""
+      }
+    ]
   },
   "F*": {
     "complexitychecks": [

--- a/processor/constants.go
+++ b/processor/constants.go
@@ -3970,7 +3970,26 @@ var languageDatabase = map[string]Language{
 				"*)",
 			},
 		},
-		Quotes:          []Quote{},
+		Quotes: []Quote{
+			{
+				Start:        "\"",
+				End:          "\"",
+				IgnoreEscape: false,
+				DocString:    false,
+			},
+			{
+				Start:        "@\"",
+				End:          "\"",
+				IgnoreEscape: true,
+				DocString:    false,
+			},
+			{
+				Start:        "\"\"\"",
+				End:          "\"\"\"",
+				IgnoreEscape: true,
+				DocString:    false,
+			},
+		},
 		NestedMultiLine: false,
 		Keywords:        []string{},
 		Heuristics:      []Heuristic{},

--- a/processor/workers_test.go
+++ b/processor/workers_test.go
@@ -2169,3 +2169,51 @@ func BenchmarkUnknownRemapLanguage(b *testing.B) {
 		}
 	})
 }
+
+// F# defines (* *) as multi-line comments but, before this fix, had no string
+// literals in languages.json. A (* inside a regular string therefore opened a
+// phantom block comment that ate the following code lines. With the string
+// literals now declared, the (* inside the string is ignored by the comment
+// scanner and each line is classified correctly.
+func TestCountStatsFSharpStringHidesBlockComment(t *testing.T) {
+	ProcessConstants()
+
+	checks := []struct {
+		name    string
+		content string
+		code    int64
+		comment int64
+	}{
+		{
+			name: "regular string hides block-comment opener",
+			content: "let s = \"(* not a comment\"\n" +
+				"let x = 1\n",
+			code:    2,
+			comment: 0,
+		},
+		{
+			name: "verbatim string hides block-comment opener",
+			content: "let s = @\"(* not a comment\"\n" +
+				"let x = 1\n",
+			code:    2,
+			comment: 0,
+		},
+		{
+			name: "real comment still counted",
+			content: "// real comment\n" +
+				"let x = 1\n",
+			code:    1,
+			comment: 1,
+		},
+	}
+
+	for _, c := range checks {
+		fileJob := FileJob{Language: "F#"}
+		fileJob.SetContent(c.content)
+		CountStats(&fileJob)
+		if fileJob.Code != c.code || fileJob.Comment != c.comment {
+			t.Errorf("%s: Code=%d Comment=%d (want Code=%d Comment=%d)",
+				c.name, fileJob.Code, fileJob.Comment, c.code, c.comment)
+		}
+	}
+}


### PR DESCRIPTION
Fixes scc mis-counting F# files where a `(*` inside a string literal opens a phantom multi-line comment.

## Summary
- Add F# string literals to `languages.json` (`quotes` was empty): regular `"…"` (escaped), verbatim `@"…"` (no escape), and triple-quoted `"""…"""` (F# 5+, no escape, may span lines).
- Regenerate `processor/constants.go` and `LANGUAGES.md` via `go generate`.
- Add `TestCountStatsFSharpStringHidesBlockComment` proving a `(*` inside a string no longer eats the following code lines.

## Root Cause
F# declares `(* … *)` as a multi-line comment but had an empty `quotes` array. scc's scanner only ignores comment delimiters while inside a declared string, so a `(*` inside any `"…"` string opened a real block comment that consumed every subsequent line as a comment until EOF or a stray `*)`. A 5-line fixture reported `Code=1, Comment=4` instead of `Code=4, Comment=1`.

F# string syntax per the [F# language reference](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/literals#strings): regular `"…"`, verbatim `@"…"`, and triple-quoted `"""…"""`. Modelled on the existing C# `@"…"` and Boo/Cangjie `"""…"""` entries.

## Validation
- [x] `go generate` (regenerates constants.go + LANGUAGES.md, no diff)
- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `go test -run TestCountStatsFSharpStringHidesBlockComment ./processor/ -v` (red on master, green after fix)
- [x] 5-line reproducer now reports `Code=4, Comment=1`

I licence this contribution under the MIT licence.