### PR TITLE
fix: use float division for COCOMO monthly wage so non-divisible avg-wage is not truncated

### DIFF
--- a/processor/cocomo.go
+++ b/processor/cocomo.go
@@ -28,7 +28,7 @@ var projectType = map[string][]float64{
 // EstimateCost calculates the cost in dollars applied using generic COCOMO weighted values based
 // on the average yearly wage
 func EstimateCost(effortApplied float64, averageWage int64, overhead float64) float64 {
-	return effortApplied * float64(averageWage/12) * overhead
+	return effortApplied * float64(averageWage) / 12 * overhead
 }
 
 // EstimateEffort calculate the effort applied using generic COCOMO weighted values

--- a/processor/cocomo_test.go
+++ b/processor/cocomo_test.go
@@ -3,6 +3,7 @@
 package processor
 
 import (
+	"math"
 	"testing"
 )
 
@@ -20,8 +21,8 @@ func TestEstimateCostManyLines(t *testing.T) {
 	eff := EstimateEffort(77873, 1)
 	got := EstimateCost(eff, 56000, 2.4)
 
-	// Should be around 2602096
-	if got < 2602000 || got > 2602100 {
+	// Should be around 2602469
+	if got < 2602460 || got > 2602480 {
 		t.Errorf("Got %f", got)
 	}
 }
@@ -33,5 +34,20 @@ func TestEstimateScheduleMonths(t *testing.T) {
 	// Should be around 2.7
 	if got < 2.6 || got > 2.8 {
 		t.Errorf("Got %f", got)
+	}
+}
+
+// TestEstimateCostMonthlyWagePrecision guards the monthly-wage division: the annual
+// wage must be converted to float BEFORE dividing by 12, otherwise an annual wage
+// that is not evenly divisible by 12 (such as the shipped default --avg-wage 56286,
+// whose monthly wage is 4690.5) is truncated to a whole number and every cost line
+// is silently under-counted.
+func TestEstimateCostMonthlyWagePrecision(t *testing.T) {
+	eff := EstimateEffort(100000, 1) // organic, default EAF
+	got := EstimateCost(eff, 56286, 2.4)
+	// 56286/12 = 4690.5, NOT 4690.
+	want := eff * (56286.0 / 12.0) * 2.4
+	if math.Abs(got-want) > 1e-6 {
+		t.Errorf("EstimateCost truncated the monthly wage: got %v want %v (diff %v)", got, want, got-want)
 	}
 }


### PR DESCRIPTION
## Summary

- `EstimateCost` computed the monthly wage as `float64(averageWage/12)` — the division `averageWage/12` is **Go integer division** (both operands `int64`), truncated to a whole number BEFORE the `float64(...)` cast runs. Any annual wage not evenly divisible by 12 was therefore silently under-counted. The shipped default `--avg-wage 56286` has a monthly wage of **4690.5**, but was truncated to **4690**.
- Fix: move the cast in front of the division → `float64(averageWage) / 12`. One-line change.

## Root cause

```go
// before — integer divide inside the cast:
return effortApplied * float64(averageWage/12) * overhead
// after  — cast before divide, so the division is float:
return effortApplied * float64(averageWage) / 12 * overhead
```

## Changes

| File | Change |
| --- | --- |
| `processor/cocomo.go` | `float64(averageWage/12)` → `float64(averageWage) / 12`. |
| `processor/cocomo_test.go` | `TestEstimateCostManyLines` expected window updated from the truncated value (`~2602096`) to the correct one (`~2602469`) — the old assertion had hardcoded the buggy output. New `TestEstimateCostMonthlyWagePrecision` asserts the non-truncated monthly wage for the default 56286 (4690.5), red on `master`'s truncated code and green after the fix. |

Different file and different concern from the open F# PR #737 (languages.json); no conflict with any open PR.

## Validation

- [x] `go test ./processor/ -run TestEstimateCost` — `TestEstimateCostManyLines` + `TestEstimateCostMonthlyWagePrecision` both pass.
- [x] Red-before-green: on `master` the new precision test fails (truncated `4690` vs `4690.5`); after the one-line fix it passes. Reverting the fix re-fails it.
- [x] `go generate` — no diff (`cocomo.go` is not a generate-input).

I licence this contribution under the MIT licence.