### PR TITLE
Fix --cocomo-project-type panic for case-variant built-in types

### DIFF
--- a/processor/cocomo.go
+++ b/processor/cocomo.go
@@ -31,13 +31,26 @@ func EstimateCost(effortApplied float64, averageWage int64, overhead float64) fl
 	return effortApplied * float64(averageWage) / 12 * overhead
 }
 
+// cocomoCoefficients returns the four Basic COCOMO coefficients [a, b, c, d]
+// for the configured project type. It guards the projectType lookup so an
+// unknown or malformed project type can never yield a nil/short slice and
+// panic the indexers below — falling back to the organic model instead.
+func cocomoCoefficients() []float64 {
+	if v, ok := projectType[CocomoProjectType]; ok && len(v) >= 4 {
+		return v
+	}
+	return projectType["organic"]
+}
+
 // EstimateEffort calculate the effort applied using generic COCOMO weighted values
 func EstimateEffort(sloc int64, eaf float64) float64 {
-	var effortApplied = projectType[CocomoProjectType][0] * math.Pow(float64(sloc)/1000, projectType[CocomoProjectType][1]) * eaf
+	c := cocomoCoefficients()
+	var effortApplied = c[0] * math.Pow(float64(sloc)/1000, c[1]) * eaf
 	return effortApplied
 }
 
 // EstimateScheduleMonths estimates the effort in months based on the result from EstimateEffort
 func EstimateScheduleMonths(effortApplied float64) float64 {
-	return projectType[CocomoProjectType][2] * math.Pow(effortApplied, projectType[CocomoProjectType][3])
+	c := cocomoCoefficients()
+	return c[2] * math.Pow(effortApplied, c[3])
 }

--- a/processor/cocomo_test.go
+++ b/processor/cocomo_test.go
@@ -4,6 +4,7 @@ package processor
 
 import (
 	"math"
+	"strings"
 	"testing"
 )
 
@@ -50,4 +51,244 @@ func TestEstimateCostMonthlyWagePrecision(t *testing.T) {
 	if math.Abs(got-want) > 1e-6 {
 		t.Errorf("EstimateCost truncated the monthly wage: got %v want %v (diff %v)", got, want, got-want)
 	}
+}
+
+// TestCocomoProjectTypeSelection is a table-driven regression test for the
+// panic triggered by `scc --cocomo-project-type Organic`. projectType is keyed
+// by the canonical lowercase name; before the fix, the membership check in
+// ProcessConstants lower-cased the value only for the lookup while the real
+// COCOMO indexers used the raw value, so any case variant of a built-in type
+// (Organic, SEMI-DETACHED, Embedded, ...) indexed a nil slice and panicked.
+// Each row drives ProcessConstants (selection) then EstimateEffort/
+// EstimateScheduleMonths (lookup) and must not panic.
+func TestCocomoProjectTypeSelection(t *testing.T) {
+	// ProcessConstants may register a custom projectType entry; both
+	// functions also read the CocomoProjectType package global, so snapshot
+	// and restore both to keep the test hermetic. (No test in this package
+	// calls t.Parallel, so sequential mutation is safe.)
+	savedType := cloneProjectTypeMap(projectType)
+	savedCocomo := CocomoProjectType
+	defer func() {
+		projectType = savedType
+		CocomoProjectType = savedCocomo
+	}()
+
+	// Baselines computed against the canonical lowercase keys (the trusted
+	// reference). Case-variant rows must reproduce these exactly, which proves
+	// the right coefficients are selected rather than silently falling back.
+	CocomoProjectType = "organic"
+	organicEffort := EstimateEffort(537, 1)
+	organicSchedule := EstimateScheduleMonths(organicEffort)
+	CocomoProjectType = "semi-detached"
+	semiEffort := EstimateEffort(537, 1)
+	semiSchedule := EstimateScheduleMonths(semiEffort)
+	CocomoProjectType = "embedded"
+	embeddedEffort := EstimateEffort(537, 1)
+	embeddedSchedule := EstimateScheduleMonths(embeddedEffort)
+
+	// Sanity: the three built-ins must produce distinct numbers, otherwise the
+	// per-type numeric assertions below would be vacuous.
+	if !(organicEffort != semiEffort && semiEffort != embeddedEffort && organicEffort != embeddedEffort) {
+		t.Fatalf("baselines not distinct: organic=%v semi=%v embedded=%v", organicEffort, semiEffort, embeddedEffort)
+	}
+
+	// Independent oracle for the custom 5-tuple: compute with its own
+	// (non-organic) coefficients so the row proves the custom tuple is selected,
+	// not a fallback. eaf is 1 here, matching EstimateEffort(537, 1).
+	customABCD := []float64{3.6, 1.20, 2.5, 0.38}
+	customEffort := customABCD[0] * math.Pow(537.0/1000, customABCD[1])
+	customSchedule := customABCD[2] * math.Pow(customEffort, customABCD[3])
+	if customEffort == organicEffort {
+		t.Fatalf("custom baseline coincides with organic — row would be vacuous")
+	}
+
+	tests := []struct {
+		name       string
+		input      string
+		wantNorm   string  // expected CocomoProjectType after ProcessConstants
+		wantEffort float64 // expected EstimateEffort(537, 1); 0 skips the check
+		wantSched  float64 // expected EstimateScheduleMonths; 0 skips the check
+	}{
+		{
+			name:       "organic lowercase canonical",
+			input:      "organic",
+			wantNorm:   "organic",
+			wantEffort: organicEffort,
+			wantSched:  organicSchedule,
+		},
+		{
+			name:       "Organic capitalized panics before fix",
+			input:      "Organic",
+			wantNorm:   "organic",
+			wantEffort: organicEffort,
+			wantSched:  organicSchedule,
+		},
+		{
+			name:       "ORGANIC all-caps",
+			input:      "ORGANIC",
+			wantNorm:   "organic",
+			wantEffort: organicEffort,
+			wantSched:  organicSchedule,
+		},
+		{
+			name:       "Semi-Detached mixed case resolves to semi-detached",
+			input:      "Semi-Detached",
+			wantNorm:   "semi-detached",
+			wantEffort: semiEffort,
+			wantSched:  semiSchedule,
+		},
+		{
+			name:       "Embedded capitalized resolves to embedded",
+			input:      "Embedded",
+			wantNorm:   "embedded",
+			wantEffort: embeddedEffort,
+			wantSched:  embeddedSchedule,
+		},
+		{
+			name:       "unknown type falls back to organic",
+			input:      "does-not-exist",
+			wantNorm:   "organic",
+			wantEffort: organicEffort,
+			wantSched:  organicSchedule,
+		},
+		{
+			name:       "custom 5-tuple with non-organic coefficients",
+			input:      "custom,3.6,1.20,2.5,0.38",
+			wantNorm:   "custom,3.6,1.20,2.5,0.38",
+			wantEffort: customEffort,
+			wantSched:  customSchedule,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			CocomoProjectType = tt.input
+			ProcessConstants()
+
+			if CocomoProjectType != tt.wantNorm {
+				t.Fatalf("CocomoProjectType = %q, want %q", CocomoProjectType, tt.wantNorm)
+			}
+
+			// Recover so any panic is contained to this subtest and reported as a
+			// clean failure. For the case-variant rows the normalization assertion
+			// above is what first catches the original regression; this net guards
+			// the custom/unknown rows where a future guard regression could panic.
+			var effort, sched float64
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("COCOMO lookup panicked for %q: %v", tt.input, r)
+					}
+				}()
+				effort = EstimateEffort(537, 1)
+				sched = EstimateScheduleMonths(effort)
+			}()
+
+			if tt.wantEffort != 0 && !floatApproxEqual(effort, tt.wantEffort) {
+				t.Errorf("effort = %v, want %v", effort, tt.wantEffort)
+			}
+			if tt.wantSched != 0 && !floatApproxEqual(sched, tt.wantSched) {
+				t.Errorf("schedule = %v, want %v", sched, tt.wantSched)
+			}
+		})
+	}
+}
+
+// TestCocomoCoefficientsGuard proves the defense-in-depth guard in
+// cocomoCoefficients: even if a caller sets an unknown project type and never
+// runs ProcessConstants (so no normalization/fallback runs), the COCOMO
+// functions fall back to organic instead of panicking on a nil slice.
+func TestCocomoCoefficientsGuard(t *testing.T) {
+	saved := CocomoProjectType
+	defer func() { CocomoProjectType = saved }()
+
+	organicEffort := EstimateEffort(537, 1)
+	organicSchedule := EstimateScheduleMonths(organicEffort)
+
+	CocomoProjectType = "totally-bogus-type"
+
+	var effort, sched float64
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("guarded lookup panicked for unknown type: %v", r)
+			}
+		}()
+		effort = EstimateEffort(537, 1)
+		sched = EstimateScheduleMonths(effort)
+	}()
+
+	if !floatApproxEqual(effort, organicEffort) {
+		t.Errorf("unknown type effort = %v, want organic %v", effort, organicEffort)
+	}
+	if !floatApproxEqual(sched, organicSchedule) {
+		t.Errorf("unknown type schedule = %v, want organic %v", sched, organicSchedule)
+	}
+}
+
+// TestCalculateCocomoSLOCCountProjectType covers the --sloccount-format COCOMO
+// path (calculateCocomoSLOCCount in formatters_cost.go) — the second panic site
+// the fix touched, which had its own direct projectType[CocomoProjectType][0..3]
+// indexings in the printed "Basic COCOMO model" lines. A case-variant project
+// type and an unknown type must both render without panicking, emitting the
+// organic coefficients via the cocomoCoefficients guard.
+func TestCalculateCocomoSLOCCountProjectType(t *testing.T) {
+	savedType := cloneProjectTypeMap(projectType)
+	savedCocomo := CocomoProjectType
+	defer func() {
+		projectType = savedType
+		CocomoProjectType = savedCocomo
+	}()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "Organic case variant", input: "Organic"},
+		{name: "unknown type falls back to organic", input: "does-not-exist"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			CocomoProjectType = tt.input
+			ProcessConstants()
+
+			var str strings.Builder
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("calculateCocomoSLOCCount panicked for %q: %v", tt.input, r)
+					}
+				}()
+				calculateCocomoSLOCCount(537, &str)
+			}()
+
+			out := str.String()
+			if !strings.Contains(out, "Basic COCOMO model") {
+				t.Fatalf("missing COCOMO model line in output:\n%s", out)
+			}
+			// Both rows resolve to organic, so the printed effort coefficients
+			// must be organic's a,b = {2.4, 1.05}, produced via the guard rather
+			// than a raw projectType[CocomoProjectType] lookup that would panic.
+			if !strings.Contains(out, "Person-Months = 2.40*(KSLOC**1.05)") {
+				t.Errorf("expected organic coefficients in output, got:\n%s", out)
+			}
+		})
+	}
+}
+
+func cloneProjectTypeMap(m map[string][]float64) map[string][]float64 {
+	out := make(map[string][]float64, len(m))
+	for k, v := range m {
+		// Deep-copy the slice so the snapshot is independent of any future
+		// in-place mutation of the live map's values.
+		cp := make([]float64, len(v))
+		copy(cp, v)
+		out[k] = cp
+	}
+	return out
+}
+
+func floatApproxEqual(a, b float64) bool {
+	return math.Abs(a-b) <= 1e-9
 }

--- a/processor/formatters_cost.go
+++ b/processor/formatters_cost.go
@@ -13,6 +13,7 @@ import (
 )
 
 func calculateCocomoSLOCCount(sumCode int64, str *strings.Builder) {
+	c := cocomoCoefficients()
 	estimatedEffort := EstimateEffort(int64(sumCode), EAF)
 	estimatedScheduleMonths := EstimateScheduleMonths(estimatedEffort)
 	estimatedPeopleRequired := 0.0
@@ -25,9 +26,9 @@ func calculateCocomoSLOCCount(sumCode int64, str *strings.Builder) {
 
 	_, _ = p.Fprintf(str, "Total Physical Source Lines of Code (SLOC)                     = %d\n", sumCode)
 	_, _ = p.Fprintf(str, "Development Effort Estimate, Person-Years (Person-Months)      = %.2f (%.2f)\n", estimatedEffort/12, estimatedEffort)
-	_, _ = p.Fprintf(str, " (Basic COCOMO model, Person-Months = %.2f*(KSLOC**%.2f)*%.2f)\n", projectType[CocomoProjectType][0], projectType[CocomoProjectType][1], EAF)
+	_, _ = p.Fprintf(str, " (Basic COCOMO model, Person-Months = %.2f*(KSLOC**%.2f)*%.2f)\n", c[0], c[1], EAF)
 	_, _ = p.Fprintf(str, "Schedule Estimate, Years (Months)                              = %.2f (%.2f)\n", estimatedScheduleMonths/12, estimatedScheduleMonths)
-	_, _ = p.Fprintf(str, " (Basic COCOMO model, Months = %.2f*(person-months**%.2f))\n", projectType[CocomoProjectType][2], projectType[CocomoProjectType][3])
+	_, _ = p.Fprintf(str, " (Basic COCOMO model, Months = %.2f*(person-months**%.2f))\n", c[2], c[3])
 	_, _ = p.Fprintf(str, "Estimated Average Number of Developers (Effort/Schedule)       = %.2f\n", estimatedPeopleRequired)
 	_, _ = p.Fprintf(str, "Total Estimated Cost to Develop                                = %s%.0f\n", CurrencySymbol, estimatedCost)
 	_, _ = p.Fprintf(str, " (average salary = %s%d/year, overhead = %.2f)\n", CurrencySymbol, AverageWage, Overhead)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -452,9 +452,15 @@ func ProcessConstants() {
 		setupCountRules()
 	}
 
-	// Configure COCOMO setting
-	_, ok := projectType[strings.ToLower(CocomoProjectType)]
-	if !ok {
+	// Configure COCOMO setting. projectType is keyed by the canonical
+	// lowercase name, so when the selection matches a built-in type we must
+	// normalize CocomoProjectType to that lowercase key — otherwise the
+	// membership check below passes for "Organic" while the real lookups in
+	// EstimateEffort/EstimateScheduleMonths index projectType["Organic"], hit
+	// a nil slice and panic. See `scc --cocomo-project-type Organic`.
+	if _, ok := projectType[strings.ToLower(CocomoProjectType)]; ok {
+		CocomoProjectType = strings.ToLower(CocomoProjectType)
+	} else {
 		// let's see if we can turn it into a custom one
 		spl := strings.Split(CocomoProjectType, ",")
 		val := []float64{}


### PR DESCRIPTION
ProcessConstants lower-cased the project-type for its membership check but the COCOMO indexers used the raw value, so any case-variant built-in (e.g. `Organic`) indexed a nil slice and panicked. Route every projectType lookup through a cocomoCoefficients guard that normalizes to canonical lowercase and falls back to organic.