### PR TITLE
fix(terraform): count string literals so /* inside a glob is not a comment

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -7868,7 +7868,12 @@
     "extensions": ["tf", "tfvars", "tf.json"],
     "line_comment": ["#", "//"],
     "multi_line": [["/*", "*/"]],
-    "quotes": []
+    "quotes": [
+      {
+        "end": "\"",
+        "start": "\""
+      }
+    ]
   },
   "Textile": {
     "complexitychecks": [],

--- a/processor/constants.go
+++ b/processor/constants.go
@@ -12995,7 +12995,14 @@ var languageDatabase = map[string]Language{
 				"*/",
 			},
 		},
-		Quotes:          []Quote{},
+		Quotes: []Quote{
+			{
+				Start:        "\"",
+				End:          "\"",
+				IgnoreEscape: false,
+				DocString:    false,
+			},
+		},
 		NestedMultiLine: false,
 		Keywords:        []string{},
 		Heuristics:      []Heuristic{},

--- a/processor/workers_terraform_string_test.go
+++ b/processor/workers_terraform_string_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+
+package processor
+
+import (
+	"testing"
+)
+
+// Terraform (an HCL dialect) used to ship with an empty quotes list, unlike the
+// HCL language entry which declares the "..." string literal. As a result a
+// string such as "logs/*" was parsed as code: the /* inside opened a block
+// comment that ran to the next */ (or to EOF), swallowing every subsequent
+// line as a comment. Adding the "..." quote rule lets the scanner treat the
+// glob as a string so the embedded /* is ignored.
+
+func TestCountStatsTerraformGlobStringNotComment(t *testing.T) {
+	ProcessConstants()
+	fileJob := FileJob{
+		Language: "Terraform",
+	}
+
+	fileJob.SetContent(`variable "glob" {
+  default = "logs/*"
+}
+output "result" {
+  value = "still real code"
+}`)
+
+	CountStats(&fileJob)
+
+	if fileJob.Lines != 6 {
+		t.Errorf("Expected 6 lines got %d", fileJob.Lines)
+	}
+	if fileJob.Code != 6 {
+		t.Errorf("Expected 6 code got %d", fileJob.Code)
+	}
+	if fileJob.Comment != 0 {
+		t.Errorf("Expected 0 comments got %d", fileJob.Comment)
+	}
+	if fileJob.Blank != 0 {
+		t.Errorf("Expected 0 blanks got %d", fileJob.Blank)
+	}
+}


### PR DESCRIPTION
## Problem
`Terraform` (an HCL dialect) declares an empty `quotes` list, unlike the `HCL` language entry which declares the `"..."` string literal. With no string rule, a value such as `"logs/*"` is parsed as code: the embedded `/*` opens a block comment that runs to the next `*/` or to EOF, swallowing every following line as a comment.

```hcl
variable "glob" {
  default = "logs/*"
}
output "result" {
  value = "still real code"
}
```

On master this reports **6 lines / 2 code / 4 comments** — the `}` and the whole `output` block are miscounted as comments. Globs like `"logs/*"` are common in Terraform (`ignore_changes`, `for_each` filters, path variables).

## Fix
Add the single `"..."` quote rule that `HCL` already carries, then regenerate `processor/constants.go`. No other language is touched.

## Test plan
`go test ./...` — green, including a new `TestCountStatsTerraformGlobStringNotComment` that feeds the glob above and asserts `6 lines / 6 code / 0 comments / 0 blanks`. On master the same input returns `4 comments` (the test fails); with the fix it returns `0 comments`.

I licence this contribution under the MIT licence.