### PR TITLE
fix(protobuf): count string literals so /* inside an option is not a comment

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -5993,7 +5993,12 @@
     "extensions": ["proto"],
     "line_comment": ["//"],
     "multi_line": [["/*", "*/"]],
-    "quotes": []
+    "quotes": [
+      {
+        "end": "\"",
+        "start": "\""
+      }
+    ]
   },
   "Puppet": {
     "complexitychecks": [

--- a/processor/constants.go
+++ b/processor/constants.go
@@ -9938,7 +9938,14 @@ var languageDatabase = map[string]Language{
 				"*/",
 			},
 		},
-		Quotes:          []Quote{},
+		Quotes: []Quote{
+			{
+				Start:        "\"",
+				End:          "\"",
+				IgnoreEscape: false,
+				DocString:    false,
+			},
+		},
 		NestedMultiLine: false,
 		Keywords:        []string{},
 		Heuristics:      []Heuristic{},

--- a/processor/workers_protobuf_string_test.go
+++ b/processor/workers_protobuf_string_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+
+package processor
+
+import (
+	"testing"
+)
+
+// Protocol Buffers declared an empty quotes list despite using "..." string
+// literals (syntax = "proto3"; option (x) = "..."; string field defaults).
+// With no string rule an option value such as "see /* legacy block" was parsed
+// as code: the embedded /* opened a block comment that ran to the next */ or
+// to EOF, swallowing every following line as a comment. Adding the "..." quote
+// rule lets the scanner treat the value as a string so the embedded /* is
+// ignored.
+
+func TestCountStatsProtobufStringNotComment(t *testing.T) {
+	ProcessConstants()
+	fileJob := FileJob{
+		Language: "Protocol Buffers",
+	}
+
+	fileJob.SetContent(`syntax = "proto3";
+package demo;
+
+option (desc) = "see /* legacy block";
+
+message Foo {
+  string name = 1;
+}`)
+
+	CountStats(&fileJob)
+
+	if fileJob.Lines != 8 {
+		t.Errorf("Expected 8 lines got %d", fileJob.Lines)
+	}
+	if fileJob.Code != 6 {
+		t.Errorf("Expected 6 code got %d", fileJob.Code)
+	}
+	if fileJob.Comment != 0 {
+		t.Errorf("Expected 0 comments got %d", fileJob.Comment)
+	}
+	if fileJob.Blank != 2 {
+		t.Errorf("Expected 2 blanks got %d", fileJob.Blank)
+	}
+}


### PR DESCRIPTION
## Problem
`Protocol Buffers` declares an empty `quotes` list, despite using `"..."` string literals throughout the language — `syntax = "proto3";`, `option java_package = "com.example";`, string field defaults, and validation regex options. With no string rule, an option value such as `"see /* legacy block"` is parsed as code: the embedded `/*` opens a block comment that runs to the next `*/` or to EOF, swallowing every following line as a comment.

```proto
syntax = "proto3";
package demo;

option (desc) = "see /* legacy block";

message Foo {
  string name = 1;
}
```

On master this reports **8 lines / 3 code / 4 comments** — the blank line, `message Foo {`, `string name = 1;` and `}` are all miscounted as comments.

## Fix
Add the single `"..."` quote rule (Protobuf string literals are double-quoted) and regenerate `processor/constants.go`. No other language is touched.

## Test plan
`go test ./...` — green, including a new `TestCountStatsProtobufStringNotComment` that feeds the option-string above and asserts `8 lines / 6 code / 0 comments / 2 blanks`. On master the same input returns `4 comments` (the test fails); with the fix it returns `0 comments`.

I licence this contribution under the MIT licence.