### PR TITLE
fix: guard zero category totals in --percent tabular output

### DIFF
--- a/processor/formatters_percent_test.go
+++ b/processor/formatters_percent_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+
+package processor
+
+import (
+	"strings"
+	"testing"
+)
+
+// A project whose files carry zero blank/comment/complexity lines used to make
+// the tabular --percent output print NaN% for those columns, because the
+// percentage divisions had no zero-total guard (unlike addLanguagePercentages
+// in the JSON path). The pct helper now guards the total==0 case so each empty
+// category reports 0.0% instead.
+
+func TestPercentNoNaNOnZeroCategory(t *testing.T) {
+	job := func() chan *FileJob {
+		c := make(chan *FileJob, 1)
+		c <- &FileJob{
+			Language:  "JSON",
+			Filename:  "a.json",
+			Extension: "json",
+			Location:  "./",
+			Lines:     1,
+			Code:      1,
+			// Blank, Comment and Complexity left at zero on purpose.
+		}
+		close(c)
+		return c
+	}
+
+	saved := Percent
+	Percent = true
+	defer func() { Percent = saved }()
+
+	for name, fn := range map[string]func(chan *FileJob) string{
+		"short": fileSummarizeShort,
+		"wide":  fileSummarizeLong,
+	} {
+		t.Run(name, func(t *testing.T) {
+			res := fn(job())
+			if strings.Contains(res, "NaN") {
+				t.Errorf("expected no NaN in --percent output, got:\n%s", res)
+			}
+			if !strings.Contains(res, "0.0%") {
+				t.Errorf("expected a 0.0%% entry for the empty categories, got:\n%s", res)
+			}
+		})
+	}
+}

--- a/processor/formatters_tabular.go
+++ b/processor/formatters_tabular.go
@@ -160,12 +160,12 @@ func fileSummarizeLong(input chan *FileJob) string {
 		if Percent {
 			_, _ = p.Fprintf(str,
 				tabularWideFormatBodyPercent,
-				float64(len(summary.Files))/float64(sumFiles)*100,
-				float64(summary.Lines)/float64(sumLines)*100,
-				float64(summary.Blank)/float64(sumBlank)*100,
-				float64(summary.Comment)/float64(sumComment)*100,
-				float64(summary.Code)/float64(sumCode)*100,
-				float64(summary.Complexity)/float64(sumComplexity)*100,
+				pct(int64(len(summary.Files)), sumFiles),
+				pct(summary.Lines, sumLines),
+				pct(summary.Blank, sumBlank),
+				pct(summary.Comment, sumComment),
+				pct(summary.Code, sumCode),
+				pct(summary.Complexity, sumComplexity),
 			)
 
 			if !UlocMode {
@@ -365,21 +365,21 @@ func fileSummarizeShort(input chan *FileJob) string {
 			if !Complexity {
 				_, _ = p.Fprintf(str,
 					tabularShortPercentLanguageFormatBody,
-					float64(len(summary.Files))/float64(sumFiles)*100,
-					float64(summary.Lines)/float64(sumLines)*100,
-					float64(summary.Blank)/float64(sumBlank)*100,
-					float64(summary.Comment)/float64(sumComment)*100,
-					float64(summary.Code)/float64(sumCode)*100,
-					float64(activeComplexity(summary.Complexity, summary.Cognitive))/float64(activeComplexity(sumComplexity, sumCognitive))*100,
+					pct(int64(len(summary.Files)), sumFiles),
+					pct(summary.Lines, sumLines),
+					pct(summary.Blank, sumBlank),
+					pct(summary.Comment, sumComment),
+					pct(summary.Code, sumCode),
+					pct(activeComplexity(summary.Complexity, summary.Cognitive), activeComplexity(sumComplexity, sumCognitive)),
 				)
 			} else {
 				_, _ = p.Fprintf(str,
 					tabularShortPercentLanguageFormatBodyNoComplexity,
-					float64(len(summary.Files))/float64(sumFiles)*100,
-					float64(summary.Lines)/float64(sumLines)*100,
-					float64(summary.Blank)/float64(sumBlank)*100,
-					float64(summary.Comment)/float64(sumComment)*100,
-					float64(summary.Code)/float64(sumCode)*100,
+					pct(int64(len(summary.Files)), sumFiles),
+					pct(summary.Lines, sumLines),
+					pct(summary.Blank, sumBlank),
+					pct(summary.Comment, sumComment),
+					pct(summary.Code, sumCode),
 				)
 			}
 
@@ -466,6 +466,17 @@ func fileSummarizeShort(input chan *FileJob) string {
 		str.WriteString(getTabularShortBreak())
 	}
 	return str.String()
+}
+
+// pct returns value as a percentage of total, guarding the total==0 case so
+// the tabular --percent output never prints NaN% for a category that has no
+// lines (e.g. a project whose files have zero blank/comment/complexity lines).
+// Mirrors the total!=0 guard already used by addLanguagePercentages for JSON.
+func pct(value, total int64) float64 {
+	if total == 0 {
+		return 0
+	}
+	return float64(value) / float64(total) * 100
 }
 
 func maxIn(i []int) int {


### PR DESCRIPTION
## Problem
The wide (`fileSummarizeLong`) and short (`fileSummarizeShort`) `--percent` rows divide each category total with **no zero guard**. A project whose files have no blank/comment/complexity lines therefore prints `NaN%` for those columns:

```
$ scc --percent a.json
JSON               1        1         0         0          1          0
Percentage       100.0%    100.0%      NaN%       NaN%     100.0%       NaN%
```

The sibling JSON path (`addLanguagePercentages`) and the `Complexity/Lines` total both already guard `total != 0` — only the tabular percentage rows were inconsistent.

## Fix
Factor the division into a `pct(value, total)` helper that returns `0` when `total == 0`, matching the JSON behaviour; each empty category now reports `0.0%`.

## Test plan
`go test ./...` — green, including a new `TestPercentNoNaNOnZeroCategory` that feeds a single file with `Blank=Comment=Complexity=0` and asserts the short and wide output contain `0.0%` and no `NaN`. On master the same input emits `NaN%` (the test fails).

I licence this contribution under the MIT licence.