### PR TITLE
fix(sql): escape the project name in the metadata rows

### DIFF
--- a/processor/formatters_sql.go
+++ b/processor/formatters_sql.go
@@ -58,7 +58,7 @@ func toSqlInsert(input chan *FileJob) string {
 	str.WriteString("\nbegin transaction;")
 	_, _ = fmt.Fprintf(str, "\ninsert into metadata values('%s', '%s', %f, %f, %f, %f);",
 		currentTime.Format("2006-01-02 15:04:05"),
-		projectName,
+		escapeSQLString(projectName),
 		es,
 		cost,
 		schedule,
@@ -71,7 +71,7 @@ func toSqlInsert(input chan *FileJob) string {
 		str.WriteString("\nbegin transaction;")
 		_, _ = fmt.Fprintf(str, "\ninsert into locomo_metadata values('%s', '%s', %f, %f, %f, %f, %f, '%s', %f);",
 			currentTime.Format("2006-01-02 15:04:05"),
-			projectName,
+			escapeSQLString(projectName),
 			result.Cost,
 			result.InputTokens,
 			result.OutputTokens,

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -853,6 +853,42 @@ func TestToSQLSingle(t *testing.T) {
 	}
 }
 
+func TestToSQLSingleEscapesProjectName(t *testing.T) {
+	inputChan := make(chan *FileJob, 1000)
+	inputChan <- &FileJob{
+		Language:   "Go",
+		Filename:   "bbbb.go",
+		Extension:  "go",
+		Location:   "./",
+		Bytes:      1000,
+		Lines:      1000,
+		Code:       1000,
+		Comment:    1000,
+		Blank:      1000,
+		Complexity: 1000,
+		Binary:     false,
+		Uloc:       99,
+	}
+	close(inputChan)
+
+	SQLProject = "it's mine"
+	defer func() { SQLProject = "" }()
+
+	res := toSql(inputChan)
+
+	if !strings.Contains(res, `insert into metadata values('`) {
+		t.Error("Expected metadata insert", res)
+	}
+
+	if !strings.Contains(res, `, 'it''s mine', `) {
+		t.Error("Expected escaped project name in metadata insert", res)
+	}
+
+	if strings.Contains(res, `'it's mine'`) {
+		t.Error("Expected no unescaped project name", res)
+	}
+}
+
 func TestFileSummarizeWide(t *testing.T) {
 	inputChan := make(chan *FileJob, 1000)
 	inputChan <- &FileJob{


### PR DESCRIPTION
I explicitly licence this contribution under the MIT licence.

## What's broken

`--format sql` writes the project name into the metadata row without escaping it, so an apostrophe produces SQL that will not execute.

```
$ scc --format sql --sql-project "it's mine" . > q.sql
$ grep "metadata values" q.sql
insert into metadata values('2026-08-15 14:49:17', 'it's mine', 0.001000, ...);

$ python3 -c "import sqlite3; sqlite3.connect(':memory:').executescript(open('q.sql').read())"
sqlite3.OperationalError: near "s": syntax error
```

It also fires with no flag at all, since the project name defaults to the scanned path, so a directory named `o'dir` is enough.

## The fix

The `t` rows in the same function already call `escapeSQLString(projectName)`. The `metadata` row did not, and neither did `locomo_metadata`, which is reachable with `--cost-comparison`. Those are the only two unescaped sites: of the five places `projectName` is interpolated, the other three were already correct, and every other interpolated string in the file (`res.Language`, `res.Location`, `res.Filename`, `result.Preset`) is escaped too.

After:

```
insert into metadata values('2026-08-15 14:49:09', 'it''s mine', 0.001000, ...);
sqlite: OK
```

## Verification

A case next to `TestToSQLSingle`, which already asserts on the exact insert string, setting `SQLProject` to a value containing an apostrophe and asserting the doubled quote in the metadata line. With the two call sites reverted it fails. `go test ./...` passes.

One note in case you see the same thing: on a machine with a comma-decimal `LANG`, four unrelated tests fail on master (`TestCalculateCocomo`, `TestPercentNoNaNOnZeroCategory` and two others) because the formatters build their printer from `os.Getenv("LANG")` while the fixtures spell numbers with a dot. `LANG=C go test ./...` is green both before and after this change.
