### PR TITLE
fix: report a failed -o write instead of claiming success

### DIFF
--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -196,7 +196,10 @@ func fileSummarizeMulti(input chan *FileJob) string {
 			} else {
 				err := os.WriteFile(t[1], []byte(val), 0600)
 				if err != nil {
-					fmt.Printf("%s unable to be written to for format %s: %s", t[1], t[0], err)
+					// A failed write must not report success: match the -o
+					// path and exit non-zero with the reason on stderr.
+					fmt.Fprintf(os.Stderr, "%s unable to be written to for format %s: %s\n", t[1], t[0], err)
+					os.Exit(1)
 				}
 			}
 		}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1113,7 +1113,12 @@ func Process() {
 	if FileOutput == "" {
 		fmt.Print(result)
 	} else {
-		_ = os.WriteFile(FileOutput, []byte(result), 0644)
+		// A failed write must not report success: follow the --report path
+		// above and exit non-zero with the reason on stderr.
+		if err := os.WriteFile(FileOutput, []byte(result), 0644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 		fmt.Println("results written to " + FileOutput)
 	}
 }

--- a/regression_test.go
+++ b/regression_test.go
@@ -632,3 +632,44 @@ func TestRegressionConfigCannotStartMcpServer(t *testing.T) {
 		t.Errorf("config --mcp must be an inert dummy flag and let the scan run, output:\n%s", string(out))
 	}
 }
+
+// TestRegressionOutputWriteFailureExits pins the reporting contract for a failed
+// output write. -o and --format-multi used to discard the os.WriteFile error and
+// still print "results written to ..." with exit 0, so a CI step that redirected
+// scc into a path it could not create silently produced no file and passed. The
+// sibling paths (--report, --hotspots -o) already exit 1 on a write failure; -o
+// and --format-multi must do the same. runSCCDir runs scc as a subprocess, so
+// this observes the real process exit code, not just the error path.
+func TestRegressionOutputWriteFailureExits(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// A path under a directory that does not exist: os.WriteFile cannot create it.
+	bad := filepath.Join(dir, "missing", "out.json")
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"output flag", []string{"-f", "json", "-o", bad}},
+		{"format multi", []string{"--format-multi", "json:" + bad}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := runSCCDir(t, dir, noGlobalConfig, tc.args...)
+			if err == nil {
+				t.Errorf("a failed write must exit non-zero, output:\n%s", out)
+			}
+			if strings.Contains(out, "results written to") {
+				t.Errorf("a failed write must not print a success message, output:\n%s", out)
+			}
+			if !strings.Contains(out, "no such file or directory") {
+				t.Errorf("a failed write must report the reason, output:\n%s", out)
+			}
+			if _, statErr := os.Stat(bad); statErr == nil {
+				t.Errorf("no file should exist at %s", bad)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I explicitly licence this contribution under the MIT licence.

## What's broken

`-o` reports success after a write that failed, and exits 0.

```
$ scc --format json -o /nonexistentdir/z.json .
results written to /nonexistentdir/z.json
$ echo $?
0
$ ls /nonexistentdir/z.json
ls: cannot access '/nonexistentdir/z.json': No such file or directory
```

`--format-multi` has the same hole, exiting 0 with the message going to stdout:

```
$ scc --format-multi 'json:/nonexistentdir/m.json' . ; echo $?
0
```

The same mistakes on the sibling paths are already handled, which is what makes this look like an oversight:

```
$ scc --hotspots --depth 20 -o /nonexistentdir/x.json . ; echo $?
open /nonexistentdir/x.json: no such file or directory
1
$ scc --report=/nonexistentdir/r.html . ; echo $?
create report file: open /nonexistentdir/r.html: no such file or directory
1
```

Read-only directories and paths that are actually directories fail the same silent way. In a CI job that is a green build with no artifact.

## The fix

`processor.go` had `_ = os.WriteFile(...)` followed unconditionally by the success line. It now checks the error, prints it to stderr and exits 1, following `runReport` a few hundred lines above, which does exactly this. `formatters.go` already built a message for the multi case but sent it to stdout and carried on, so it goes to stderr and exits too.

After:

```
$ scc --format json -o /nonexistentdir/z.json . ; echo $?
open /nonexistentdir/z.json: no such file or directory
1
$ scc --format-multi 'json:/nonexistentdir/m.json' . ; echo $?
/nonexistentdir/m.json unable to be written to for format json: open /nonexistentdir/m.json: no such file or directory
1
```

A successful write is unchanged, still `results written to ...` and exit 0.

`os.Exit(1)` rather than returning an error, because `Process()` is called from cobra's `Run:`, which has no error return, and the report path at `processor.go:932` already resolves that the same way. Happy to plumb an error through instead if you would rather change the signature.

**This changes an exit code**, from 0 to 1, on a case that previously failed silently. That is the point of the change, but it is a visible difference for anyone whose script currently ignores it.

## Verification

`TestRegressionOutputWriteFailureExits` in `regression_test.go`, one subtest per path. It observes the real exit code: `runSCCDir` runs the test binary as a subprocess, so `os.Exit(1)` is a genuine child-process exit. It asserts non-zero exit, absence of the success message, presence of the reason, and that no file was created. With both source changes reverted and the test kept, both subtests fail.

`LANG=C go test ./...` passes.

A note in case you see it too: on a machine with a comma-decimal `LANG`, four unrelated tests fail on master, because the formatters build their printer from `os.Getenv("LANG")` while the fixtures spell numbers with a dot. `LANG=C` is green before and after.

## On issue #510

I looked at whether this explains #510 and I do not think it does. That reporter got the tabular summary written instead of JSON, which is the unknown-format fallback from a `json2`-less binary, matching your reply that the action needed updating. Their target directory was writable, so no write failed and nothing was swallowed. Same family of symptom, different cause.
