### PR TITLE
fix(openmetrics): emit parseable OpenMetrics

### DIFF
--- a/processor/formatters_misc.go
+++ b/processor/formatters_misc.go
@@ -9,24 +9,91 @@ import (
 	"go.yaml.in/yaml/v2"
 )
 
-var openMetricsMetadata = `# TYPE scc_files gauge
+// openMetricsMetric describes a single OpenMetrics metric family. OpenMetrics requires all
+// samples of a family to be contiguous, so output is generated metric family by metric family
+// rather than language by language.
+type openMetricsMetric struct {
+	name     string
+	metadata string
+	// summary extracts the sample value from a language summary. A nil value means the metric
+	// has no samples in the per-file output.
+	summary func(LanguageSummary) int64
+	file    func(*FileJob) int64
+}
+
+var openMetricsMetrics = []openMetricsMetric{
+	{
+		name: "files",
+		metadata: `# TYPE scc_files gauge
 # HELP scc_files Number of sourcecode files.
-# TYPE scc_lines gauge
+`,
+		summary: func(l LanguageSummary) int64 { return l.Count },
+	},
+	{
+		name: "lines",
+		metadata: `# TYPE scc_lines gauge
 # HELP scc_lines Number of lines.
-# TYPE scc_code gauge
+`,
+		summary: func(l LanguageSummary) int64 { return l.Lines },
+		file:    func(f *FileJob) int64 { return f.Lines },
+	},
+	{
+		name: "code",
+		metadata: `# TYPE scc_code gauge
 # HELP scc_code Number of lines of actual code.
-# TYPE scc_comments gauge
+`,
+		summary: func(l LanguageSummary) int64 { return l.Code },
+		file:    func(f *FileJob) int64 { return f.Code },
+	},
+	{
+		name: "comments",
+		metadata: `# TYPE scc_comments gauge
 # HELP scc_comments Number of comments.
-# TYPE scc_blanks gauge
+`,
+		summary: func(l LanguageSummary) int64 { return l.Comment },
+		file:    func(f *FileJob) int64 { return f.Comment },
+	},
+	{
+		name: "blanks",
+		metadata: `# TYPE scc_blanks gauge
 # HELP scc_blanks Number of blank lines.
-# TYPE scc_complexity gauge
+`,
+		summary: func(l LanguageSummary) int64 { return l.Blank },
+		file:    func(f *FileJob) int64 { return f.Blank },
+	},
+	{
+		name: "complexity",
+		metadata: `# TYPE scc_complexity gauge
 # HELP scc_complexity Code complexity.
-# TYPE scc_bytes gauge
+`,
+		summary: func(l LanguageSummary) int64 { return l.Complexity },
+		file:    func(f *FileJob) int64 { return f.Complexity },
+	},
+	{
+		name: "bytes",
+		metadata: `# TYPE scc_bytes gauge
 # UNIT scc_bytes bytes
 # HELP scc_bytes Size in bytes.
-`
+`,
+		summary: func(l LanguageSummary) int64 { return l.Bytes },
+		file:    func(f *FileJob) int64 { return f.Bytes },
+	},
+}
+
 var openMetricsSummaryRecordFormat = "scc_%s{language=\"%s\"} %d\n"
 var openMetricsFileRecordFormat = "scc_%s{language=\"%s\",file=\"%s\"} %d\n"
+
+var openMetricsLabelEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`"`, `\"`,
+	"\n", `\n`,
+)
+
+// escapeOpenMetricsLabelValue escapes the characters that are not permitted raw inside an
+// OpenMetrics label value.
+func escapeOpenMetricsLabelValue(value string) string {
+	return openMetricsLabelEscaper.Replace(value)
+}
 
 // LanguageSummary to generate output like cloc
 type languageSummaryCloc struct {
@@ -146,30 +213,36 @@ func toOpenMetricsSummary(input chan *FileJob) string {
 	language = sortLanguageSummary(language)
 
 	sb := &strings.Builder{}
-	sb.WriteString(openMetricsMetadata)
-	for _, result := range language {
-		_, _ = fmt.Fprintf(sb, openMetricsSummaryRecordFormat, "files", result.Name, result.Count)
-		_, _ = fmt.Fprintf(sb, openMetricsSummaryRecordFormat, "lines", result.Name, result.Lines)
-		_, _ = fmt.Fprintf(sb, openMetricsSummaryRecordFormat, "code", result.Name, result.Code)
-		_, _ = fmt.Fprintf(sb, openMetricsSummaryRecordFormat, "comments", result.Name, result.Comment)
-		_, _ = fmt.Fprintf(sb, openMetricsSummaryRecordFormat, "blanks", result.Name, result.Blank)
-		_, _ = fmt.Fprintf(sb, openMetricsSummaryRecordFormat, "complexity", result.Name, result.Complexity)
-		_, _ = fmt.Fprintf(sb, openMetricsSummaryRecordFormat, "bytes", result.Name, result.Bytes)
+	for _, metric := range openMetricsMetrics {
+		sb.WriteString(metric.metadata)
+		for _, result := range language {
+			_, _ = fmt.Fprintf(sb, openMetricsSummaryRecordFormat, metric.name,
+				escapeOpenMetricsLabelValue(result.Name), metric.summary(result))
+		}
 	}
+	sb.WriteString("# EOF\n")
 	return sb.String()
 }
 
 func toOpenMetricsFiles(input chan *FileJob) string {
-	sb := &strings.Builder{}
-	sb.WriteString(openMetricsMetadata)
+	// The samples of a metric family must be contiguous, so the whole input is drained before
+	// anything is written.
+	var files []*FileJob
 	for file := range input {
-		var filename = strings.ReplaceAll(file.Location, "\\", "\\\\")
-		_, _ = fmt.Fprintf(sb, openMetricsFileRecordFormat, "lines", file.Language, filename, file.Lines)
-		_, _ = fmt.Fprintf(sb, openMetricsFileRecordFormat, "code", file.Language, filename, file.Code)
-		_, _ = fmt.Fprintf(sb, openMetricsFileRecordFormat, "comments", file.Language, filename, file.Comment)
-		_, _ = fmt.Fprintf(sb, openMetricsFileRecordFormat, "blanks", file.Language, filename, file.Blank)
-		_, _ = fmt.Fprintf(sb, openMetricsFileRecordFormat, "complexity", file.Language, filename, file.Complexity)
-		_, _ = fmt.Fprintf(sb, openMetricsFileRecordFormat, "bytes", file.Language, filename, file.Bytes)
+		files = append(files, file)
+	}
+
+	sb := &strings.Builder{}
+	for _, metric := range openMetricsMetrics {
+		sb.WriteString(metric.metadata)
+		if metric.file == nil {
+			continue
+		}
+		for _, file := range files {
+			_, _ = fmt.Fprintf(sb, openMetricsFileRecordFormat, metric.name,
+				escapeOpenMetricsLabelValue(file.Language),
+				escapeOpenMetricsLabelValue(file.Location), metric.file(file))
+		}
 	}
 	sb.WriteString("# EOF\n")
 	return sb.String()

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -782,30 +782,146 @@ func TestToOpenMetricsMultiple(t *testing.T) {
 
 	var expectedResult = `# TYPE scc_files gauge
 # HELP scc_files Number of sourcecode files.
+scc_files{language="Go"} 2
 # TYPE scc_lines gauge
 # HELP scc_lines Number of lines.
+scc_lines{language="Go"} 2000
 # TYPE scc_code gauge
 # HELP scc_code Number of lines of actual code.
+scc_code{language="Go"} 2000
 # TYPE scc_comments gauge
 # HELP scc_comments Number of comments.
+scc_comments{language="Go"} 2000
 # TYPE scc_blanks gauge
 # HELP scc_blanks Number of blank lines.
+scc_blanks{language="Go"} 2000
 # TYPE scc_complexity gauge
 # HELP scc_complexity Code complexity.
+scc_complexity{language="Go"} 2000
 # TYPE scc_bytes gauge
 # UNIT scc_bytes bytes
 # HELP scc_bytes Size in bytes.
-scc_files{language="Go"} 2
-scc_lines{language="Go"} 2000
-scc_code{language="Go"} 2000
-scc_comments{language="Go"} 2000
-scc_blanks{language="Go"} 2000
-scc_complexity{language="Go"} 2000
 scc_bytes{language="Go"} 2000
+# EOF
 `
 
 	if res != expectedResult {
 		t.Error("Expected OpenMetrics return", res)
+	}
+}
+
+// assertOpenMetricsFamiliesContiguous checks that every sample line of a metric family appears
+// in one unbroken run, which OpenMetrics requires, and that the output ends with the # EOF
+// terminator.
+func assertOpenMetricsFamiliesContiguous(t *testing.T, res string) {
+	t.Helper()
+
+	if !strings.HasSuffix(res, "# EOF\n") {
+		t.Error("Expected output to be terminated by # EOF", res)
+	}
+
+	var order []string
+	seen := map[string]bool{}
+	previous := ""
+
+	for _, line := range strings.Split(res, "\n") {
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		name, _, found := strings.Cut(line, "{")
+		if !found {
+			t.Error("Expected a labelled sample line", line)
+			continue
+		}
+
+		if name != previous {
+			if seen[name] {
+				t.Error("Samples of family are not contiguous: "+name, res)
+			}
+			seen[name] = true
+			order = append(order, name)
+			previous = name
+		}
+	}
+
+	if len(order) == 0 {
+		t.Error("Expected at least one sample", res)
+	}
+}
+
+func TestToOpenMetricsFamiliesContiguous(t *testing.T) {
+	inputChan := make(chan *FileJob, 1000)
+	for _, language := range []string{"Go", "Python", "Rust"} {
+		for i := 0; i < 2; i++ {
+			inputChan <- &FileJob{
+				Language:   language,
+				Filename:   fmt.Sprintf("a%d.x", i),
+				Location:   fmt.Sprintf("./a%d.x", i),
+				Bytes:      1000,
+				Lines:      1000,
+				Code:       1000,
+				Comment:    1000,
+				Blank:      1000,
+				Complexity: 1000,
+			}
+		}
+	}
+	close(inputChan)
+
+	Files = false
+	res := toOpenMetrics(inputChan)
+
+	assertOpenMetricsFamiliesContiguous(t, res)
+}
+
+func TestToOpenMetricsFilesFamiliesContiguous(t *testing.T) {
+	inputChan := make(chan *FileJob, 1000)
+	for _, language := range []string{"Go", "Python", "Rust"} {
+		for i := 0; i < 2; i++ {
+			inputChan <- &FileJob{
+				Language:   language,
+				Filename:   fmt.Sprintf("a%d.x", i),
+				Location:   fmt.Sprintf("./a%d.x", i),
+				Bytes:      1000,
+				Lines:      1000,
+				Code:       1000,
+				Comment:    1000,
+				Blank:      1000,
+				Complexity: 1000,
+			}
+		}
+	}
+	close(inputChan)
+
+	Files = true
+	res := toOpenMetrics(inputChan)
+	Files = false
+
+	assertOpenMetricsFamiliesContiguous(t, res)
+}
+
+func TestToOpenMetricsFilesEscapesLabelValues(t *testing.T) {
+	inputChan := make(chan *FileJob, 1000)
+	inputChan <- &FileJob{
+		Language:   `we"ird`,
+		Filename:   `we"ird.py`,
+		Location:   "./we\"ird\\new\nline.py",
+		Bytes:      1000,
+		Lines:      1000,
+		Code:       1000,
+		Comment:    1000,
+		Blank:      1000,
+		Complexity: 1000,
+	}
+	close(inputChan)
+
+	Files = true
+	res := toOpenMetrics(inputChan)
+	Files = false
+
+	if !strings.Contains(res, `scc_lines{language="we\"ird",file="./we\"ird\\new\nline.py"} 1000`) {
+		t.Error("Expected quote, backslash and newline to be escaped in label values", res)
 	}
 }
 
@@ -1015,26 +1131,27 @@ func TestFileSummarizeOpenMetrics(t *testing.T) {
 
 	var expectedResult = `# TYPE scc_files gauge
 # HELP scc_files Number of sourcecode files.
+scc_files{language="Go"} 1
 # TYPE scc_lines gauge
 # HELP scc_lines Number of lines.
+scc_lines{language="Go"} 1000
 # TYPE scc_code gauge
 # HELP scc_code Number of lines of actual code.
+scc_code{language="Go"} 1000
 # TYPE scc_comments gauge
 # HELP scc_comments Number of comments.
+scc_comments{language="Go"} 1000
 # TYPE scc_blanks gauge
 # HELP scc_blanks Number of blank lines.
+scc_blanks{language="Go"} 1000
 # TYPE scc_complexity gauge
 # HELP scc_complexity Code complexity.
+scc_complexity{language="Go"} 1000
 # TYPE scc_bytes gauge
 # UNIT scc_bytes bytes
 # HELP scc_bytes Size in bytes.
-scc_files{language="Go"} 1
-scc_lines{language="Go"} 1000
-scc_code{language="Go"} 1000
-scc_comments{language="Go"} 1000
-scc_blanks{language="Go"} 1000
-scc_complexity{language="Go"} 1000
 scc_bytes{language="Go"} 1000
+# EOF
 `
 
 	if res != expectedResult {
@@ -1069,22 +1186,22 @@ func TestFileSummarizeOpenMetricsPerFile(t *testing.T) {
 # HELP scc_files Number of sourcecode files.
 # TYPE scc_lines gauge
 # HELP scc_lines Number of lines.
+scc_lines{language="Go",file="C:\\bbbb.go"} 1000
 # TYPE scc_code gauge
 # HELP scc_code Number of lines of actual code.
+scc_code{language="Go",file="C:\\bbbb.go"} 1000
 # TYPE scc_comments gauge
 # HELP scc_comments Number of comments.
+scc_comments{language="Go",file="C:\\bbbb.go"} 1000
 # TYPE scc_blanks gauge
 # HELP scc_blanks Number of blank lines.
+scc_blanks{language="Go",file="C:\\bbbb.go"} 1000
 # TYPE scc_complexity gauge
 # HELP scc_complexity Code complexity.
+scc_complexity{language="Go",file="C:\\bbbb.go"} 1000
 # TYPE scc_bytes gauge
 # UNIT scc_bytes bytes
 # HELP scc_bytes Size in bytes.
-scc_lines{language="Go",file="C:\\bbbb.go"} 1000
-scc_code{language="Go",file="C:\\bbbb.go"} 1000
-scc_comments{language="Go",file="C:\\bbbb.go"} 1000
-scc_blanks{language="Go",file="C:\\bbbb.go"} 1000
-scc_complexity{language="Go",file="C:\\bbbb.go"} 1000
 scc_bytes{language="Go",file="C:\\bbbb.go"} 1000
 # EOF
 `


### PR DESCRIPTION
I explicitly licence this contribution under the MIT licence.

## What's broken

`--format openmetrics` does not produce parseable OpenMetrics, for three independent reasons.

**1. Metric families are interleaved.** All seven `# TYPE`/`# HELP` blocks are written up front, then each language emits all seven metrics, so the samples of one family are scattered through the output. The spec requires them contiguous.

```
$ scc --format openmetrics . > s.txt
$ python3 -c "from prometheus_client.openmetrics.parser import text_string_to_metric_families as om; list(om(open('s.txt').read()))"
ValueError: Clashing name: scc_files
```

**2. The summary path never writes `# EOF`.** The per-file path does. Without it the parser reports `Missing # EOF at end`.

**3. Label values are not escaped.** A quote in a filename closes the label early:

```
$ cp a.py 'we"ird.py' && scc --format openmetrics --by-file .
scc_lines{language="Python",file="/tmp/.../we"ird.py"} 1
```

The file label escapes backslashes but never quotes, and the language label is not escaped at all. The sibling formatters already handle this: CSV writes `"we""ird.py"`, SQL writes `'it''s.py'`.

## The fix

Both loops now iterate metric family first, then language or file, so each family's metadata is immediately followed by its own samples. The metadata blob became a table pairing each metric with its accessors, which is what makes that ordering possible. The summary path gained the missing `# EOF`, and a small escaper covering `\`, `"` and newline is applied to both label sites.

`toOpenMetricsFiles` now drains the channel into a slice first, since samples of one family can no longer be emitted as each file streams past.

After, on a directory containing `we"ird.py`:

```
--format openmetrics            OK  7 families, 14 samples
--format openmetrics --by-file  OK  7 families, 18 samples
scc_lines{language="Python",file="/tmp/.../we\"ird.py"} 1
```

**The sample values are unchanged.** Comparing sorted non-comment lines before and after: the summary output is byte-identical, and the by-file output differs only in the escaped quotes. Only grouping, the terminator, and escaping changed.

One thing to flag: `scc_files` has no per-file sample, so in `--by-file` its metadata is emitted with zero samples. The parser accepts that, and it matches the previous behaviour where it also had no per-file samples, but it is now visible as a lone `# TYPE`/`# HELP` pair.

## Verification

The three existing tests are exact-equality assertions, so their expected literals are rewritten to the new grouping rather than weakened. `TestFileSummarizeOpenMetricsPerFile` keeps its `C:\\bbbb.go` backslash expectation, which still passes.

Three new tests: two asserting family contiguity and the `# EOF` terminator, one asserting label escaping. The contiguity helper was mutation-checked by temporarily restoring the language-first loop, which fails it with `Samples of family are not contiguous: scc_files`, so it is not vacuous.

`LANG=C go test ./...` passes, and the `prometheus_client` OpenMetrics parser accepts both output modes.

Same locale note as my other PRs: on a comma-decimal `LANG` four unrelated tests fail on master, because the formatters build their printer from `os.Getenv("LANG")`. `LANG=C` is green before and after.
