### PR TITLE
fix: --format-multi drops targets whose path contains a colon

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -449,6 +449,25 @@ func TestMultipleFormatWriteFile(t *testing.T) {
 	}
 }
 
+// TestMultipleFormatWriteFileColonPath is a regression test for
+// https://github.com/boyter/scc/issues/290 where --format-multi silently
+// discarded any target containing a colon, such as a Windows absolute path
+// like csv:C:\folder\out.csv, because the format:target pair was split on
+// every colon rather than only the first one.
+func TestMultipleFormatWriteFileColonPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputCSV := filepath.Join(tmpDir, "C:output.csv")
+
+	_, err := runSCC("--format-multi", "csv:"+outputCSV)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info, err := os.Stat(outputCSV); err != nil || info.Size() <= 0 {
+		t.Fatalf("csv write to colon containing path failed for %s", outputCSV)
+	}
+}
+
 func TestRecursivelyIgnore(t *testing.T) {
 	tmpDir := t.TempDir()
 	err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("ignore-git.txt\n"), 0644)

--- a/processor/formatters.go
+++ b/processor/formatters.go
@@ -148,7 +148,9 @@ func fileSummarizeMulti(input chan *FileJob) string {
 
 	// for each output pump the results into
 	for s := range strings.SplitSeq(FormatMulti, ",") {
-		t := strings.Split(s, ":")
+		// Split on the first colon only, because the target may itself contain
+		// colons, such as a Windows absolute path like C:\folder\out.csv
+		t := strings.SplitN(s, ":", 2)
 		if len(t) == 2 {
 			i := make(chan *FileJob, len(results))
 


### PR DESCRIPTION
## What's broken

`--format-multi` silently ignores any output target whose path contains a colon, such as a Windows absolute path. No file is written and the exit code is still 0.

Fixes #290

## Repro

```
$ scc . --format-multi "csv:/tmp/demo/C:out.csv"; echo "exit=$?"; ls /tmp/demo/
exit=0
a.go            <- no csv, no error

$ scc . --format-multi "csv:/tmp/demo/C:out.csv"; ls /tmp/demo/
a.go   C:out.csv <- after
```

## The fix

`fileSummarizeMulti` split each `format:target` pair with `strings.Split(s, ":")` and then required exactly two parts. A target containing a colon yields three or more, so the pair was dropped. `strings.SplitN(s, ":", 2)` splits on the first colon only, which is what the format is. Targets `stdout` and `stderr` are unaffected.

## Verification

Added `TestMultipleFormatWriteFileColonPath` in `main_test.go`, which runs scc with a colon in the output path and asserts the file exists and is non-empty. Reverting `SplitN` back to `Split` fails it.

`go test ./...` has 5 failures on my machine (`TestIssue457`, the two cocomo tests, `TestPercentNoNaNOnZeroCategory`, `TestFileSummarizeLongWeightedComplexity`). They are identical on a clean `master`, so they are pre-existing. `gofmt` clean.
