### PR TITLE
fix(lua): long string start and end brackets are swapped

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -4360,8 +4360,8 @@
         "start": "'"
       },
       {
-        "end": "[[",
-        "start": "]]",
+        "end": "]]",
+        "start": "[[",
         "ignoreEscape": true
       }
     ],
@@ -4410,8 +4410,8 @@
         "start": "`"
       },
       {
-        "end": "[[",
-        "start": "]]",
+        "end": "]]",
+        "start": "[[",
         "ignoreEscape": true
       }
     ],
@@ -8775,8 +8775,8 @@
         "start": "\""
       },
       {
-        "end": "[[",
-        "start": "]]",
+        "end": "]]",
+        "start": "[[",
         "ignoreEscape": true
       }
     ]

--- a/processor/constants.go
+++ b/processor/constants.go
@@ -7317,8 +7317,8 @@ var languageDatabase = map[string]Language{
 				DocString:    false,
 			},
 			{
-				Start:        "]]",
-				End:          "[[",
+				Start:        "[[",
+				End:          "]]",
 				IgnoreEscape: true,
 				DocString:    false,
 			},
@@ -7403,8 +7403,8 @@ var languageDatabase = map[string]Language{
 				DocString:    false,
 			},
 			{
-				Start:        "]]",
-				End:          "[[",
+				Start:        "[[",
+				End:          "]]",
 				IgnoreEscape: true,
 				DocString:    false,
 			},
@@ -14465,8 +14465,8 @@ var languageDatabase = map[string]Language{
 				DocString:    false,
 			},
 			{
-				Start:        "]]",
-				End:          "[[",
+				Start:        "[[",
+				End:          "]]",
 				IgnoreEscape: true,
 				DocString:    false,
 			},

--- a/processor/workers_lua_longstring_test.go
+++ b/processor/workers_lua_longstring_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+
+package processor
+
+import (
+	"testing"
+)
+
+// Lua, Luau and XMake declared their long bracket string literal with start and
+// end swapped ("start": "]]", "end": "[["). Because the opening [[ never
+// matched, a -- inside a long string was treated as a line comment, and a
+// stray ]] in ordinary code (such as the nested index a[b[1]]) opened a string
+// that ran until the next [[ or EOF, hiding the comments and code after it.
+// Declaring the quote as start "[[" / end "]]" makes the scanner see the real
+// string so the embedded -- is ignored.
+
+func TestCountStatsLuaLongStringCommentMarkerNotComment(t *testing.T) {
+	ProcessConstants()
+
+	for _, language := range []string{"Lua", "Luau", "XMake"} {
+		fileJob := FileJob{
+			Language: language,
+		}
+
+		fileJob.SetContent(`local s = [[
+-- not a comment, just string content
+]]
+print(s)`)
+
+		CountStats(&fileJob)
+
+		if fileJob.Lines != 4 {
+			t.Errorf("%s: Expected 4 lines got %d", language, fileJob.Lines)
+		}
+		if fileJob.Code != 4 {
+			t.Errorf("%s: Expected 4 code got %d", language, fileJob.Code)
+		}
+		if fileJob.Comment != 0 {
+			t.Errorf("%s: Expected 0 comments got %d", language, fileJob.Comment)
+		}
+	}
+}
+
+func TestCountStatsLuaNestedIndexDoesNotOpenString(t *testing.T) {
+	ProcessConstants()
+	fileJob := FileJob{
+		Language: "Lua",
+	}
+
+	fileJob.SetContent(`local x = a[b[1]]
+-- a real comment
+local y = 2`)
+
+	CountStats(&fileJob)
+
+	if fileJob.Lines != 3 {
+		t.Errorf("Expected 3 lines got %d", fileJob.Lines)
+	}
+	if fileJob.Code != 2 {
+		t.Errorf("Expected 2 code got %d", fileJob.Code)
+	}
+	if fileJob.Comment != 1 {
+		t.Errorf("Expected 1 comment got %d", fileJob.Comment)
+	}
+}
+
+// Guard the fix does not break real Lua block comments, which use --[[ ... ]].
+func TestCountStatsLuaBlockCommentStillCounted(t *testing.T) {
+	ProcessConstants()
+	fileJob := FileJob{
+		Language: "Lua",
+	}
+
+	fileJob.SetContent(`--[[
+block comment body
+]]
+local x = 1`)
+
+	CountStats(&fileJob)
+
+	if fileJob.Comment != 3 {
+		t.Errorf("Expected 3 comments got %d", fileJob.Comment)
+	}
+	if fileJob.Code != 1 {
+		t.Errorf("Expected 1 code got %d", fileJob.Code)
+	}
+}


### PR DESCRIPTION
## What's broken

Lua, Luau and XMake declare their long-bracket string with `start` and `end` swapped in `languages.json`:

```json
{ "end": "[[", "start": "]]", "ignoreEscape": true }
```

So `[[` never opens a string. Two consequences, in opposite directions:

- a `--` inside a long string is counted as a comment
- a bare `]]` in ordinary code, like the nested index `data[keys[1]]`, opens a bogus string that swallows every following line until the next `[[` or EOF

`Factor` in the same file has the correct orientation, which is what makes the mistake visible.

## Repro

A file with a long string containing `--`, then `data[keys[1]]`, then one real comment:

```
                Lines  Blanks  Comments  Code
before   Lua        9       0         0     9
after    Lua        9       0         1     8
```

The real comment was invisible because the earlier `]]` had opened a string that never closed.

## The fix

Swap the two fields on those three languages, then `go generate ./...` to regenerate `processor/constants.go`.

## Verification

Three tests. Two assert the fixed behaviour across all three languages, and the third asserts that `--[[ ... ]]` block comments are still counted as comments, which is the guard against over-correcting. Swapping the brackets back in the generated constants fails the first two, and deliberately not the third.

`go test ./...` shows only the 5 failures already present on a clean `master` (`TestIssue457`, both cocomo tests, `TestPercentNoNaNOnZeroCategory`, `TestFileSummarizeLongWeightedComplexity`). I re-ran `go generate` myself and confirmed the committed constants match byte for byte, so the generate check stays green.
