### PR TITLE
fix: correct the block comment delimiters for MATLAB and Racket

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -4495,7 +4495,7 @@
       "fprintf("
     ],
     "line_comment": ["%"],
-    "multi_line": [["%{", "}%"]],
+    "multi_line": [["%{", "%}"]],
     "quotes": [
       {
         "end": "'",
@@ -6252,7 +6252,7 @@
     ],
     "extensions": ["rkt"],
     "line_comment": [";"],
-    "multi_line": [["|#", "#|"]],
+    "multi_line": [["#|", "|#"]],
     "nestedmultiline": true,
     "quotes": [
       {

--- a/processor/constants.go
+++ b/processor/constants.go
@@ -7508,7 +7508,7 @@ var languageDatabase = map[string]Language{
 		MultiLine: [][]string{
 			{
 				"%{",
-				"}%",
+				"%}",
 			},
 		},
 		Quotes: []Quote{
@@ -10345,8 +10345,8 @@ var languageDatabase = map[string]Language{
 		ExtensionFile: false,
 		MultiLine: [][]string{
 			{
-				"|#",
 				"#|",
+				"|#",
 			},
 		},
 		Quotes: []Quote{

--- a/processor/workers_block_comment_delimiter_test.go
+++ b/processor/workers_block_comment_delimiter_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+
+package processor
+
+import (
+	"testing"
+)
+
+// MATLAB declared its block comment as %{ ... }% and Racket declared its own
+// reversed as |# ... #|. In both cases the real opener never closed, so the
+// scanner ran the comment to EOF and swallowed the rest of the file.
+
+func TestCountStatsMatlabBlockCommentCloses(t *testing.T) {
+	ProcessConstants()
+	fileJob := FileJob{
+		Language: "MATLAB",
+	}
+
+	fileJob.SetContent(`function c = add(a, b)
+
+%{
+ A block comment
+ over three lines
+%}
+
+c = a + b;
+end`)
+
+	CountStats(&fileJob)
+
+	if fileJob.Lines != 9 {
+		t.Errorf("Expected 9 lines got %d", fileJob.Lines)
+	}
+	if fileJob.Code != 3 {
+		t.Errorf("Expected 3 code got %d", fileJob.Code)
+	}
+	if fileJob.Comment != 4 {
+		t.Errorf("Expected 4 comments got %d", fileJob.Comment)
+	}
+	if fileJob.Blank != 2 {
+		t.Errorf("Expected 2 blanks got %d", fileJob.Blank)
+	}
+}
+
+func TestCountStatsRacketBlockCommentCloses(t *testing.T) {
+	ProcessConstants()
+	fileJob := FileJob{
+		Language: "Racket",
+	}
+
+	fileJob.SetContent(`#lang racket
+
+#|
+ A block comment
+ over three lines
+|#
+
+(define (add a b)
+  (+ a b))`)
+
+	CountStats(&fileJob)
+
+	if fileJob.Lines != 9 {
+		t.Errorf("Expected 9 lines got %d", fileJob.Lines)
+	}
+	if fileJob.Code != 3 {
+		t.Errorf("Expected 3 code got %d", fileJob.Code)
+	}
+	if fileJob.Comment != 4 {
+		t.Errorf("Expected 4 comments got %d", fileJob.Comment)
+	}
+	if fileJob.Blank != 2 {
+		t.Errorf("Expected 2 blanks got %d", fileJob.Blank)
+	}
+}
+
+func TestCountStatsRacketNestedBlockComment(t *testing.T) {
+	ProcessConstants()
+	fileJob := FileJob{
+		Language: "Racket",
+	}
+
+	fileJob.SetContent(`#lang racket
+
+#|
+ outer #| inner |# still outer
+|#
+
+(displayln "hi")`)
+
+	CountStats(&fileJob)
+
+	if fileJob.Lines != 7 {
+		t.Errorf("Expected 7 lines got %d", fileJob.Lines)
+	}
+	if fileJob.Code != 2 {
+		t.Errorf("Expected 2 code got %d", fileJob.Code)
+	}
+	if fileJob.Comment != 3 {
+		t.Errorf("Expected 3 comments got %d", fileJob.Comment)
+	}
+	if fileJob.Blank != 2 {
+		t.Errorf("Expected 2 blanks got %d", fileJob.Blank)
+	}
+}


### PR DESCRIPTION
A `%{ ... %}` block in a MATLAB file swallows everything after it. The closer is listed as `}%`, so the opener never matches and the scanner runs the comment to EOF - a nine-line function counts 1 code / 7 comments / 1 blank, where it should be 3 / 4 / 2.

Racket is the same thing from the other side, its pair stored backwards as `|#` then `#|`. Lisp and Scheme sit in the same file with it the right way round, which is what convinced me it wasnt deliberate.

Nothing moves in `examples/language` either way - `racket.rkt` has no block comments and theres no MATLAB file in there to check against.

I explicitly licence this contribution under the MIT licence.
