### PR TITLE
fix(sql): --locomo output has no CREATE TABLE for locomo_metadata

### DIFF
--- a/processor/formatters_sql.go
+++ b/processor/formatters_sql.go
@@ -136,6 +136,22 @@ create table t        (
 	str.WriteString(`
 );`)
 
+	// toSqlInsert writes into locomo_metadata when --locomo is set, so the table has to
+	// be created here too or the generated script fails with "no such table".
+	if Locomo {
+		str.WriteString(`
+create table locomo_metadata (
+             timestamp text,
+             Project   text,
+             estimated_llm_cost real,
+             estimated_llm_input_tokens real,
+             estimated_llm_output_tokens real,
+             estimated_llm_generation_seconds real,
+             estimated_llm_review_hours real,
+             estimated_llm_preset text,
+             estimated_llm_cycles real);`)
+	}
+
 	str.WriteString(toSqlInsert(input))
 	return str.String()
 }

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -1005,6 +1005,41 @@ func TestToSQLSingleEscapesProjectName(t *testing.T) {
 	}
 }
 
+func TestToSQLLocomoCreatesLocomoMetadataTable(t *testing.T) {
+	inputChan := make(chan *FileJob, 1000)
+	inputChan <- &FileJob{
+		Language:   "Go",
+		Filename:   "bbbb.go",
+		Extension:  "go",
+		Location:   "./",
+		Bytes:      1000,
+		Lines:      1000,
+		Code:       1000,
+		Comment:    1000,
+		Blank:      1000,
+		Complexity: 1000,
+		Uloc:       99,
+	}
+	close(inputChan)
+
+	Locomo = true
+	defer func() { Locomo = false }()
+
+	res := toSql(inputChan)
+
+	if !strings.Contains(res, `insert into locomo_metadata values(`) {
+		t.Error("Expected locomo_metadata insert", res)
+	}
+
+	if !strings.Contains(res, `create table locomo_metadata`) {
+		t.Error("Expected create table locomo_metadata so the script can be replayed", res)
+	}
+
+	if strings.Index(res, `create table locomo_metadata`) > strings.Index(res, `insert into locomo_metadata`) {
+		t.Error("Expected create table locomo_metadata before its insert", res)
+	}
+}
+
 func TestFileSummarizeWide(t *testing.T) {
 	inputChan := make(chan *FileJob, 1000)
 	inputChan <- &FileJob{


### PR DESCRIPTION
With `--locomo`, the SQL output has inserts into `locomo_metadata` but no `CREATE TABLE` for it, so the script cannot be replayed. The README documents this pipeline at line 1264 (`scc --format sql ... | sqlite3 code.db`):

```
before   $ scc --format sql --locomo . > out.sql && sqlite3 code.db < out.sql
         Error: no such table: locomo_metadata

after    OK
         sqlite> select estimated_llm_preset, round(estimated_llm_cost,4) from locomo_metadata;
         medium|34.5515
```

`toSql` emits the `t` table but not the locomo one, while `toSqlInsert` writes rows into both. The create statement now goes out whenever `Locomo` is set, with the nine columns in the order the insert supplies them. Output is unchanged without `--locomo`.

Test added in `formatters_test.go`; making the branch unreachable fails it. `go test ./...` passes. Four tests in that package fail under a comma decimal separator locale, identically on an unmodified checkout, so I ran with `LANG=C`. gofmt and vet clean. `languages.json` untouched, so no `go generate` needed.

AI disclosure: written with Claude Code. I replayed the generated SQL through sqlite before and after, and checked the mutation myself.