### PR TITLE
Add --count-unsupported to count unrecognised files as Unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Flags:
       --count-as string                     count extension as language [e.g. jsp:htm,chead:"C Header" maps extension jsp to html and chead to C Header]
       --count-as-pattern stringArray        count files matching a path pattern as a new named category backed by a base language [repeatable; pattern is glob by default, prefix with re: for regex; e.g. *_spec.rb:"Ruby Spec":Ruby or re:\.test\.js$:"JavaScript Tests":JavaScript]
       --count-ignore                        set to allow .gitignore and .ignore files to be counted
+      --count-unsupported                   count files with an unrecognised language under an "Unknown" category as plain text
       --coupling                            render the change-coupling report (file pairs that change together over recent git history)
       --coupling-for string                 blast-radius view: given a file path, show what tends to change with it over recent git history
       --coupling-weighted                   weight coupling by file complexity so pairs of complex files rank above generated/data-file churn (implies --coupling)

--- a/config.go
+++ b/config.go
@@ -344,6 +344,7 @@ func registerFlags(flags *pflag.FlagSet, b *flagBindings) {
 	flags.BoolVar(boolVar(&processor.GitIgnore), "no-gitignore", false, "disables .gitignore file logic")
 	flags.BoolVar(boolVar(&processor.GitModuleIgnore), "no-gitmodule", false, "disables .gitmodules file logic")
 	flags.BoolVar(boolVar(&processor.CountIgnore), "count-ignore", false, "set to allow .gitignore and .ignore files to be counted")
+	flags.BoolVar(boolVar(&processor.CountUnsupported), "count-unsupported", false, "count files with an unrecognised language under an \"Unknown\" category as plain text")
 	flags.StringArrayVar(sliceVar(&processor.IgnoreFiles), "ignore-file", nil, "path to an additional gitignore-format ignore file, applied from the scan root; repeat to add more, later files and any in-tree ignore files take precedence")
 	flags.BoolVar(boolVar(&processor.Debug), "debug", false, "enable debug output")
 	// Registered with an empty default; the real default is merged back post-parse.

--- a/processor/file.go
+++ b/processor/file.go
@@ -113,74 +113,87 @@ func newFileJob(path, name string, fileInfo os.FileInfo) *FileJob {
 		}
 	}
 
-	if len(language) != 0 {
-		// check if extensions in the allow list, which should limit to just those extensions
-		if len(AllowListExtensions) != 0 {
-			ok := false
-			for _, x := range AllowListExtensions {
-				if x == extension {
-					ok = true
-				}
-			}
+	// If detection found nothing we normally skip the file. With
+	// --count-unsupported we instead count it under the "Unknown" category as
+	// plain text (issue #464). Binary files are still dropped later once a null
+	// byte is seen while counting, so this only surfaces text files scc doesn't
+	// yet recognise.
+	unsupported := false
+	if len(language) == 0 {
+		if !CountUnsupported {
+			printWarnF("skipping file unknown extension: %s", name)
+			return nil
+		}
+		language = []string{UnknownLanguage}
+		unsupported = true
+	}
 
-			if !ok {
-				printWarnF("skipping file as not in allow list: %s", name)
-				return nil
+	// check if extensions in the allow list, which should limit to just those extensions
+	if len(AllowListExtensions) != 0 {
+		ok := false
+		for _, x := range AllowListExtensions {
+			if x == extension {
+				ok = true
 			}
 		}
 
-		// check if we should exclude this type
-		if len(ExcludeListExtensions) != 0 {
-			ok := true
-			for _, x := range ExcludeListExtensions {
-				if x == extension {
-					ok = false
-				}
-			}
+		if !ok {
+			printWarnF("skipping file as not in allow list: %s", name)
+			return nil
+		}
+	}
 
-			if !ok {
-				printWarnF("skipping file as in exclude list: %s", name)
-				return nil
+	// check if we should exclude this type
+	if len(ExcludeListExtensions) != 0 {
+		ok := true
+		for _, x := range ExcludeListExtensions {
+			if x == extension {
+				ok = false
 			}
 		}
 
-		if len(ExcludeFilename) != 0 {
-			ok := true
-			for _, x := range ExcludeFilename {
-				if strings.Contains(name, x) {
-					ok = false
-				}
-			}
+		if !ok {
+			printWarnF("skipping file as in exclude list: %s", name)
+			return nil
+		}
+	}
 
-			if !ok {
-				printWarnF("skipping file as in exclude file list: %s", name)
-				return nil
+	if len(ExcludeFilename) != 0 {
+		ok := true
+		for _, x := range ExcludeFilename {
+			if strings.Contains(name, x) {
+				ok = false
 			}
 		}
 
+		if !ok {
+			printWarnF("skipping file as in exclude file list: %s", name)
+			return nil
+		}
+	}
+
+	// Unknown carries no language features by design so there is nothing to
+	// load; loading it would also miss the language database entirely.
+	if !unsupported {
 		for _, l := range language {
 			LoadLanguageFeature(l)
 		}
-
-		if !CountIgnore {
-			for _, l := range language {
-				if l == "ignore" || l == "gitignore" {
-					return nil
-				}
-			}
-		}
-
-		return &FileJob{
-			Location:          path,
-			Symlocation:       symPath,
-			Filename:          name,
-			Extension:         extension,
-			PossibleLanguages: language,
-			Bytes:             fileInfo.Size(),
-		}
-	} else {
-		printWarnF("skipping file unknown extension: %s", name)
 	}
 
-	return nil
+	if !CountIgnore {
+		for _, l := range language {
+			if l == "ignore" || l == "gitignore" {
+				return nil
+			}
+		}
+	}
+
+	return &FileJob{
+		Location:          path,
+		Symlocation:       symPath,
+		Filename:          name,
+		Extension:         extension,
+		PossibleLanguages: language,
+		Bytes:             fileInfo.Size(),
+	}
 }

--- a/processor/file_test.go
+++ b/processor/file_test.go
@@ -268,6 +268,68 @@ func TestNewFileJobBrokenSymlink(t *testing.T) {
 	}
 }
 
+func TestNewFileJobUnsupportedSkippedByDefault(t *testing.T) {
+	ProcessConstants()
+	cleanVisitedPaths()
+	AllowListExtensions = []string{}
+	CountUnsupported = false
+
+	dir, _ := filepath.EvalSymlinks(t.TempDir())
+	file := filepath.Join(dir, "data.unknownext")
+	if err := os.WriteFile(file, []byte("one\ntwo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fi, _ := os.Stat(file)
+	job := newFileJob(file, "data.unknownext", fi)
+
+	if job != nil {
+		t.Error("Expected nil for unsupported file without --count-unsupported, got", job)
+	}
+}
+
+func TestNewFileJobUnsupportedCounted(t *testing.T) {
+	ProcessConstants()
+	cleanVisitedPaths()
+	AllowListExtensions = []string{}
+	CountUnsupported = true
+	defer func() { CountUnsupported = false }()
+
+	dir, _ := filepath.EvalSymlinks(t.TempDir())
+	file := filepath.Join(dir, "data.unknownext")
+	if err := os.WriteFile(file, []byte("one\ntwo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fi, _ := os.Stat(file)
+	job := newFileJob(file, "data.unknownext", fi)
+
+	if job == nil {
+		t.Fatal("Expected a FileJob for unsupported file with --count-unsupported, got nil")
+	}
+	if len(job.PossibleLanguages) != 1 || job.PossibleLanguages[0] != UnknownLanguage {
+		t.Errorf("Expected language %q got %v", UnknownLanguage, job.PossibleLanguages)
+	}
+
+	// It should count as plain text: lines and code populated, no comments or
+	// complexity since the Unknown category carries no language features.
+	job.Content = []byte("one\ntwo\n")
+	job.Language = DetermineLanguage(job.Filename, job.Language, job.PossibleLanguages, job.Content)
+	if job.Language != UnknownLanguage {
+		t.Errorf("Expected resolved language %q got %q", UnknownLanguage, job.Language)
+	}
+	CountStats(job)
+	if job.Lines != 2 {
+		t.Errorf("Expected 2 lines got %d", job.Lines)
+	}
+	if job.Code != 2 {
+		t.Errorf("Expected 2 code lines got %d", job.Code)
+	}
+	if job.Comment != 0 || job.Complexity != 0 {
+		t.Errorf("Expected no comments/complexity got comment=%d complexity=%d", job.Comment, job.Complexity)
+	}
+}
+
 func BenchmarkGetExtensionDifferent(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -110,6 +110,10 @@ var SccIgnore = false
 // CountIgnore should we count ignore files?
 var CountIgnore = false
 
+// CountUnsupported when set counts files scc does not recognise under an
+// "Unknown" category, treating them as plain text. See issue #464.
+var CountUnsupported = false
+
 // IgnoreFiles are paths to additional ignore files supplied via --ignore-file.
 // They are applied as a low priority base layer in the order supplied so a later
 // file can override an earlier one, and any in-tree .gitignore/.ignore/.sccignore

--- a/processor/workers.go
+++ b/processor/workers.go
@@ -29,6 +29,11 @@ const (
 // SheBang is a global constant for indicating a shebang file header
 const SheBang string = "#!"
 
+// UnknownLanguage is the category files are counted under when --count-unsupported
+// is set and scc does not recognise the file's language. It has no language
+// features so such files are counted as plain text (no comments or complexity).
+const UnknownLanguage string = "Unknown"
+
 // LineType what type of line are processing
 type LineType int32
 


### PR DESCRIPTION
This adds a `--count-unsupported` flag that counts files whose language scc doesn't recognise under an "Unknown" category as plain text, rather than skipping them silently, as requested in #464.

By default nothing changes: unrecognised files are still skipped with the usual warning. When `--count-unsupported` is set, a file that detection can't place is labelled `Unknown` and counted like plain text. The `Unknown` category deliberately carries no language features, so no comments or complexity are attributed to it, and the counter's null-byte check still runs, so anything that turns out to be binary is dropped exactly as before. The net effect is that only genuine non-binary text files surface, which makes it easy to spot odd files that might warrant a new language definition or that were quietly missing from the metrics.

The change slots into `newFileJob`: the "unknown extension" path now either skips (default) or relabels to `Unknown` and falls through the existing allow/exclude filters, so the flag composes with `--include-ext`, `--exclude-ext`, and friends. `CountStats` already substitutes empty tries when a language has no registered features, so `Unknown` needs no special-casing downstream.

Testing: added `TestNewFileJobUnsupportedSkippedByDefault` and `TestNewFileJobUnsupportedCounted` (the latter also runs the file through `CountStats` to confirm it counts as plain text with zero comments/complexity). Full `go test ./...` passes, plus a manual run over a mixed directory confirming a text file with an unknown extension lands under `Unknown` while a binary file with an unknown extension is still skipped.

I license this contribution under the MIT licence.
