### PR TITLE
fix: escape language names and file paths in html output

### DIFF
--- a/processor/formatters_misc.go
+++ b/processor/formatters_misc.go
@@ -4,6 +4,7 @@ package processor
 
 import (
 	"fmt"
+	"html"
 	"strings"
 
 	"go.yaml.in/yaml/v2"
@@ -336,7 +337,7 @@ func toHtmlTable(input chan *FileJob) string {
 		<th>%d</th>
 		<th>%d</th>
 		<th>%d</th>
-	</tr>`, r.Name, len(r.Files), r.Lines, r.Blank, r.Comment, r.Code, r.Complexity, r.Bytes, len(ulocLanguageCount[r.Name]))
+	</tr>`, html.EscapeString(r.Name), len(r.Files), r.Lines, r.Blank, r.Comment, r.Code, r.Complexity, r.Bytes, len(ulocLanguageCount[r.Name]))
 
 		if Files {
 			sortSummaryFiles(&r)
@@ -352,7 +353,7 @@ func toHtmlTable(input chan *FileJob) string {
 		<td>%d</td>
 		<td>%d</td>
 		<td>%d</td>
-	</tr>`, res.Location, res.Lines, res.Blank, res.Comment, res.Code, res.Complexity, res.Bytes, res.Uloc)
+	</tr>`, html.EscapeString(res.Location), res.Lines, res.Blank, res.Comment, res.Code, res.Complexity, res.Bytes, res.Uloc)
 			}
 		}
 

--- a/processor/formatters_test.go
+++ b/processor/formatters_test.go
@@ -1663,6 +1663,32 @@ func TestToHTMLTable(t *testing.T) {
 	}
 }
 
+// Language names and file paths are attacker/user controlled, so they have to be
+// escaped or they break out of the cell and produce invalid HTML.
+func TestToHTMLTableEscapesLanguageAndLocation(t *testing.T) {
+	t.Cleanup(func() { Files = false })
+	Files = true
+
+	inputChan := make(chan *FileJob, 1000)
+	inputChan <- &FileJob{
+		Language: `<script>alert("x")</script>`,
+		Filename: "b&b.go",
+		Location: `./a<b>&"c".go`,
+	}
+	close(inputChan)
+	res := toHtmlTable(inputChan)
+
+	if strings.Contains(res, "<script>") {
+		t.Error("expected the language name to be escaped, got", res)
+	}
+	if !strings.Contains(res, `<th>&lt;script&gt;alert(&#34;x&#34;)&lt;/script&gt;</th>`) {
+		t.Error("expected escaped language cell, got", res)
+	}
+	if !strings.Contains(res, `<td>./a&lt;b&gt;&amp;&#34;c&#34;.go</td>`) {
+		t.Error("expected escaped location cell, got", res)
+	}
+}
+
 func TestUnicodeAwareTrimAscii(t *testing.T) {
 	tmp := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.md"
 	res := unicodeAwareTrim(tmp, shortFormatFileTruncate)


### PR DESCRIPTION
`--format html` and `--format html-table` interpolate file paths and language names into table cells with no escaping, so anything containing `<`, `>`, `&` or `"` breaks out of the cell and produces invalid HTML.

With files named `a<b>.go` and `b".py`:

```
$ scc --by-file --format html-table
before:  <td>/tmp/scctest/a<b>.go</td>
         <td>/tmp/scctest/b".py</td>
after:   <td>/tmp/scctest/a&lt;b&gt;.go</td>
         <td>/tmp/scctest/b&#34;.py</td>
```

`--count-as-pattern` category names reach the header cells the same way:

```
$ scc --count-as-pattern '*.go:<script>alert(1)</script>:Go' --format html-table
before:  <th><script>alert(1)</script></th>
after:   <th>&lt;script&gt;alert(1)&lt;/script&gt;</th>
```

That matters because the html output is a file people open in a browser, and on CI the paths and category names can come from the repository being scanned.

Two `html.EscapeString` calls in `toHtmlTable`. The numeric columns are `%d` so they need nothing. `toHtml` wraps the same function and is covered by the change.

AI-assisted: written with Claude Code, reviewed and tested by me before sending.
