### PR TITLE
docs: add limit and cognitive to the MCP analyze parameter table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1649,10 +1649,12 @@ The MCP server exposes three tools:
 | `path` | string | no | Directory or file path to analyze. Defaults to current directory. |
 | `sort` | string | no | Column to sort by: `files`, `name`, `lines`, `blanks`, `code`, `comments`, `complexity`, `bytes`. Default: `files`. |
 | `by_file` | boolean | no | If true, return per-file results instead of per-language summary. |
+| `limit` | number | no | Maximum number of files to return per language when `by_file` is true. Default: `10`. Set to `-1` for unlimited. |
 | `include_ext` | string | no | Comma-separated file extensions to include (e.g. `go,java,js`). |
 | `exclude_ext` | string | no | Comma-separated file extensions to exclude (e.g. `json,xml`). |
 | `no_duplicates` | boolean | no | Remove duplicate files from stats. |
 | `no_min_gen` | boolean | no | Ignore minified or generated files. |
+| `cognitive` | boolean | no | Also compute nesting-weighted cognitive complexity. Off by default, in which case the `cognitive` field is `0`. |
 | `locomo` | boolean | no | Include LOCOMO (LLM cost) estimation in results. |
 | `locomo_preset` | string | no | LOCOMO model preset: `large`, `medium`, `small`, `local`. Default: `medium`. |
 

--- a/README.md
+++ b/README.md
@@ -1658,7 +1658,7 @@ The MCP server exposes three tools:
 | `locomo` | boolean | no | Include LOCOMO (LLM cost) estimation in results. |
 | `locomo_preset` | string | no | LOCOMO model preset: `large`, `medium`, `small`, `local`. Default: `medium`. |
 
-Results are returned as JSON with per-language breakdown (files, lines, code, comments, blanks, complexity, bytes), totals, and COCOMO cost/schedule estimates. When `locomo` is enabled, LOCOMO estimates (token counts, cost, generation time, review hours) are also included.
+Results are returned as JSON with per-language breakdown (files, lines, code, comments, blanks, complexity, cognitive, bytes), totals, and COCOMO cost/schedule estimates. When `locomo` is enabled, LOCOMO estimates (token counts, cost, generation time, review hours) are also included.
 
 **`hotspots`** - Rank the files in a git repository by hotspot score (complexity × change-frequency over recent history), surfacing the files most likely to need refactoring or close review.
 


### PR DESCRIPTION
The `hotspots` and `coupling` tables each document their own `limit`, but `analyze` has the same parameter and is the only table that doesn't mention it. It looks like an oversight, and the published v4.1.0 binary, pointed at this repo's own `processor/` at that tag, confirms it matters.

- With `by_file` enabled, Go reports `"files": 91` but returns 10 entries beacuse `limit` defaults to 10 per language.
- Setting `limit` to `-1` returns all 91, while `limit` set to 3 returns 3.
- Enabling `cognitive` gives Go `"cognitive": 13043`; without it, the field is still present and sat at `0`.

This hits anyone driving scc through MCP, which in practise means an LLM client using the table to decide what it can pass. You ask for a per-file breakdown and get ten files beside a count of 91, with no documented cutoff or way to lift it. Thats a fairly convincing way to think you've got the whole codebase when youve only got ten files per language.

The `hotspots` and `coupling` tables stay exactly as they are. Nothing outside the `analyze` block moves, and no behaviour changes - this is only the docs half of the mismatch.

I explicitly licence this contribution under the MIT licence.
